### PR TITLE
pre-screening-overviews

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,7 +15,7 @@
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right">
         <li><a href="#"><span class="glyphicon glyphicon-dashboard" aria-hidden="true"></span>Dashboard</a></li>
-        <li><a href="/prescreen_select-service.html"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>Pre-Screener</a></li>
+        <li><a href="/prescreen_select.html"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>Pre-Screener</a></li>
         <li><a href="#"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span>Add Client</a></li>
         <li><a href="#"><span class="glyphicon glyphicon-search" aria-hidden="true"></span>Search Clients</a></li>
         <li class="divider"></li>

--- a/prescreen_access-now.html
+++ b/prescreen_access-now.html
@@ -1,0 +1,72 @@
+---
+layout: default
+login: false
+---
+
+<p>This is the application for <strong>Access Now</strong>. You can learn more about Access Now <a href="about_access-now.html">here</a></p>
+
+<hr>
+
+<form class="prescreen-form">
+
+  <!-- houshold size -->
+  <div class="form-group">
+    <div class="input-group">
+      <label for="household-size">What is your household size?</label>
+      <input type="text" class="form-control" id="household-size" placeholder="# of residents">
+      <!-- <input type="text" class="form-control" placeholder=".col-xs-2"> -->
+    </div>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" id="checkboxSuccess" value="option1">
+        I don't know
+      </label>
+    </div>
+  </div>
+
+  <!-- income -->
+  <div class="form-group">
+    <label for="household-income">What is your household income?</label>
+    <div class="input-group">
+      <div class="input-group-addon">$</div>
+      <input type="text" class="form-control" id="household-income" placeholder="Amount">
+      <div class="input-group-addon">.00</div>
+    </div>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" id="checkboxSuccess" value="option1">
+        I don't know
+      </label>
+    </div>
+  </div>
+
+  <!-- do you have health insurance? -->
+  <div class="form-group">
+    <p><strong>Do you have health insurance?</strong></p>
+    <label class="radio-inline">
+      <input type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1"> Yes
+    </label>
+    <label class="radio-inline">
+      <input type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2"> No
+    </label>
+    <label class="radio-inline">
+      <input type="radio" name="inlineRadioOptions" id="inlineRadio3" value="option3"> I don't know
+    </label>
+  </div>
+
+  <!-- are you eligible for medicare/medicaid? -->
+  <div class="form-group">
+    <p><strong>Are you eligible for Medicare/Medicaid?</strong></p>
+    <label class="radio-inline">
+      <input type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1"> Yes
+    </label>
+    <label class="radio-inline">
+      <input type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2"> No
+    </label>
+    <label class="radio-inline">
+      <input type="radio" name="inlineRadioOptions" id="inlineRadio3" value="option3"> I don't know
+    </label>
+  </div>
+
+
+</form>

--- a/prescreen_select.html
+++ b/prescreen_select.html
@@ -1,0 +1,18 @@
+---
+layout: default
+login: false
+---
+
+<p>Select a service for pre-screening.</p>
+
+<hr>
+
+<div class="pre-screeners">
+  <a href="prescreen_access-now.html"><div class="col-md-12 pre-screener-option">Access Now <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></div></a>
+
+  <a href="prescreen_access-now.html"><div class="col-md-12 pre-screener-option">Cross Over <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></div></a>
+
+  <a href="prescreen_access-now.html"><div class="col-md-12 pre-screener-option">Daily Planet <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></div></a>
+
+  <a href="prescreen_access-now.html"><div class="col-md-12 pre-screener-option">VA Coordinated Care <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></div></a>
+</div>

--- a/statics/app.css
+++ b/statics/app.css
@@ -9,3 +9,29 @@ body {
  *
  */
 .nav a .glyphicon:before { margin-right:8px; }
+
+
+/* PRE-SCREENING
+ *
+ *
+ */
+.pre-screeners {}
+.pre-screener-option {
+  padding:1.2em;
+  color:#fff;
+  background:#333;
+  margin-bottom:1em;
+  text-transform: uppercase;
+  font-weight:300;
+  letter-spacing: .1em;
+}
+.pre-screener-option .glyphicon {
+  float:right;
+}
+.pre-screener-option:nth-child(2n) {
+  background-color:#e5e5e5;
+}
+
+.prescreen-form .form-group {
+  margin-bottom:3em;
+}


### PR DESCRIPTION
### What changed?
- Adding a view for [pre-screening-overview](https://github.com/codeforamerica/rva-screening/blob/pre-screening-view/prescreen_select.html)
- Adding a view for [Access Now pre-screening](https://github.com/codeforamerica/rva-screening/blob/pre-screening-view/prescreen_access-now.html)
- some extra CSS for both of the above :point_up: 

![rva-screener-prescreenoverview](https://cloud.githubusercontent.com/assets/1943001/7280009/d8ea9760-e8d4-11e4-9b15-976bf229821b.gif)
