### PR TITLE
adding shutil for recursive dir copying, #47

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,7 @@ login_manager = LoginManager()
 login_manager.init_app(app)
 login_manager.login_view = 'login'
 
+
 from app.assets import assets
 assets.init_app(app)
 

--- a/app/assets.py
+++ b/app/assets.py
@@ -1,8 +1,21 @@
 from flask_assets import Bundle, Environment
+import shutil
+
+# used to copy font files from Bootstrap
+def copy(src, dest):
+  try:
+    shutil.copytree(src, dest)
+  except OSError as e:
+    print(' * Files in %s are copied!' % src)
+
+bootstrap = 'node_modules/bootstrap/dist/'
+
+# Copy Bootstrap Fonts
+copy('app/static/{}fonts'.format(bootstrap), 'app/static/public/fonts/')
 
 js = Bundle(
   'node_modules/jquery/dist/jquery.js',
-  'node_modules/bootstrap/dist/js/bootstrap.js',
+  '{}js/bootstrap.js'.format(bootstrap),
   'js/main.js',
   output='./public/js/app.js',
   depends=('js/*.js', 'js/**/*.js')
@@ -10,7 +23,7 @@ js = Bundle(
 
 css = Bundle(
   Bundle(
-    'node_modules/bootstrap/dist/css/bootstrap.css',
+    '{}css/bootstrap.css'.format(bootstrap),
     filters='cssmin',
     output='./public/css/bootstrap.css'
   ),


### PR DESCRIPTION
### What changed?
- Adding a the `copy` function to `assets.py` using `import shutil` to copy over fonts from Bootstrap. This probably isn't the most elegant way, but it does the job for now! resolves #47 
- Since `shutil` will error out when the font directory, the `copy` function handles this and just prints to the console
- using `.format()` for bootstrap path
