### PR TITLE
adding utf8 encoding to pashword hash, fixes #32

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -12,7 +12,7 @@ def login():
   if request.method == 'POST':
     user = User.query.filter(User.email == request.form['email']).first()
     if user:
-      if bcrypt.check_password_hash(user.password, request.form['password']):
+      if bcrypt.check_password_hash(user.password.encode('utf8'), request.form['password']):
         user.authenticated = True
         db.session.add(user)
         db.session.commit()


### PR DESCRIPTION
### What changed?
- adding `.encode('utf8')` to password hash to prevent unicode error in #32
