### PR TITLE
add pre-screening result logic and more fee information on result page

### DIFF
--- a/app/static/sass/_base.scss
+++ b/app/static/sass/_base.scss
@@ -123,6 +123,10 @@ body {
   margin-bottom:3em;
 }
 
+.service-pre-screen-result {
+  margin-bottom: 5em;
+}
+
 
 /* PATIENT DETAILS
  *

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,20 +1,45 @@
 {% extends "base.html" %}
 {% block content %}
 	{% for service in services %}
-		{% if service.likely_eligible %}
-      <p class="alert alert-success"><span class="glyphicon glyphicon-ok push-right"></span>Good news!</p>
- 			<h3>You are likely eligible for {{ service.name }}.</h3>
- 		{% else %}
- 			<h3>You are likely not eligible for {{ service.name }}.</h3>
-    	{% endif %}
+        <div class="service-pre-screen-result">
+    		{% if service.eligible %}
+                <p class="alert alert-success">
+                    <span class="glyphicon glyphicon-ok push-right"></span>
+                    Good news!
+                </p>
+     			<h3>You are likely eligible for {{ service.name }}.</h3>
+                {% if service.general_fees %}
+                    {% for fee in service.general_fees %}
+                        <p>{{fee[0]}}: ${{fee[1]}}</p>
+                    {% endfor %}
+                {% endif %}
+                {% if service.name == 'Access Now' %}
+                    Access Now's services are free.
+                {% endif %}
+     		{% else %}
+     			<h3>You are likely not eligible for {{ service.name }}.</h3>
+        	{% endif %}
+            {% if service.sliding_scale %}
+                <h5>You're likely to fall in the {{service.sliding_scale}} section of the sliding scale.</h5>
+                {% if service.sliding_scale != 'Full fee' %}
+                    {% for fee in service.sliding_scale_fees %}
+                        <p>{{fee[0]}}: ${{fee[1]}}</p>
+                    {% endfor %}
+                {% endif %}
+            {% endif %}
+        </div>
     {% endfor %}
+
     {% if patient %}
     	<a href="{{ url_for('save_prescreening_updates', patientid=patient.id) }}">
         Return to details for {{ patient }}.
     	</a>
-    {% else %}
+
+ {#<!--    {% else %}
     	<p>Would you save this information into a new patient record?</p>
     	<a type="button" class="btn btn-success" href="{{ url_for('new_patient') }}">Yes</a>
-    	<a type="button" class="btn btn-default" href="{{ url_for('index') }}">No thanks</a>
+    	<a type="button" class="btn btn-default" href="{{ url_for('index') }}">No thanks</a> -->
+ #}
     {% endif %}
 {% endblock %}
+


### PR DESCRIPTION
Pre-screener now calculates FPL and uses that information, plus insurance status/eligibility, to make some rough guesses about service eligibility and sliding scale fees. The result page now shows sliding scale info and some fee information instead of just "you do/don't qualify".
