### PR TITLE
Landing href fix

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,11 +19,13 @@
         TODO: add "new" and "recent" classes based on actual database timestamps.
         Using the index count is a hack just to show the visuals and does not work
         as expected!
+
+        TODO: calculate percent completion realistically, not randomly with the loop.index
         -->
         <li class="patient-list-item clearfix col-sm-6 {% if loop.index < 3 %}new{% endif %} {% if loop.index == 3 %}recent{% endif %}">
           <h3>{{ patient.full_name or patient.first_name }}</h3>
           <p class="patient-dob">DOB: {{ patient.dob }}</p>
-          <div class="completion-wrapper"><div class="completion high" style="width:87%"></div></div><div class="completion-percentage">{{ comp_per }}87%</div>
+          <div class="completion-wrapper"><div class="completion high" style="width:{{ loop.index }}9%"></div></div><div class="completion-percentage">{{ loop.index }}9%</div>
           <p class="patient-lastedit left">Last edited by: <a href="#">____</a> at <a href="#">Richmond Resource Center</a></p>
           <a class="btn btn-default btn-sm right" href="{{ url_for('patient_details', id=patient.id) }}">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
         </li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,27 +12,15 @@
         <input type="text" class="search form-control" placeholder="Search your patients..."/>
       </div>
 
-      <!-- this macro is just for templating help, will remove when grabbing from DB! -->
-      {% macro patient(name, class, editor='Me', service='Where I work', comp_cat='med', comp_per='50') %}
-        <li class="patient-list-item clearfix col-sm-6 {{ class }}">
-          <h3 class="patient-name">{{ name }}</h3>
-          <p class="patient-dob">DOB: xx/xx/xxxx</p>
-          <div class="completion-wrapper"><div class="completion {{ comp_cat }}" style="width:{{ comp_per }}%"></div></div><div class="completion-percentage">{{ comp_per }}%</div>
-          <p class="patient-lastedit left">Last edited by: <a href="#">{{ editor }}</a> at <a href="#">{{ service }}</a></p>
-          <a class="btn btn-default btn-sm right" href="#">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
-        </li>
-      {%- endmacro %}
-
       <ul class="list">
 
-        {{ patient( "Jane Doe", "new", "- - -", "Crossover", "high", "90" ) }}
-        {{ patient( "John Doe", "new", "- - -", "Crossover", "med", "74" ) }}
-        {{ patient( "Flint Clempsey", "new", "- - -", "Crossover", "low", "6" ) }}
-        {{ patient( "Audrey Walker", "recent", "Me", "Where I work", "high", "94" ) }}
-        {{ patient( "Cliff Sider", "recent", "Me", "Where I work", "high", "100" ) }}
-
         {% for patient in patients %}
-        <li class="patient-list-item clearfix col-sm-6">
+        <!--
+        TODO: add "new" and "recent" classes based on actual database timestamps.
+        Using the index count is a hack just to show the visuals and does not work
+        as expected!
+        -->
+        <li class="patient-list-item clearfix col-sm-6 {% if loop.index < 3 %}new{% endif %} {% if loop.index == 3 %}recent{% endif %}">
           <h3>{{ patient.full_name or patient.first_name }}</h3>
           <p class="patient-dob">DOB: {{ patient.dob }}</p>
           <div class="completion-wrapper"><div class="completion high" style="width:87%"></div></div><div class="completion-percentage">{{ comp_per }}87%</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,7 +37,7 @@
           <p class="patient-dob">DOB: {{ patient.dob }}</p>
           <div class="completion-wrapper"><div class="completion high" style="width:87%"></div></div><div class="completion-percentage">{{ comp_per }}87%</div>
           <p class="patient-lastedit left">Last edited by: <a href="#">____</a> at <a href="#">Richmond Resource Center</a></p>
-          <a class="btn btn-default btn-sm right" href="#">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
+          <a class="btn btn-default btn-sm right" href="{{ url_for('patient_details', id=patient.id) }}">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
### What changed?
- Updating the landing `index.html` page to only use database entries, since fake patients didn't have any links to `patient_details.html`, which would be confusing during testing.
- Super hacky usage of the `{{ loop.index }}` to make some of visuals work :hocho: 
