### PR TITLE
fixes to a few bugs/UI issues we saw today

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -106,7 +106,7 @@ class HouseholdMember(db.Model):
   patientid = db.Column(db.Integer, db.ForeignKey("patient.id"))
   full_name = db.Column(db.String(64))
   dob = db.Column(db.Date())
-  ssn = db.Column(db.String(9))
+  ssn = db.Column(db.String(11))
   relationship = db.Column(db.String(32))
 
 class IncomeSource(db.Model):

--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -4,7 +4,7 @@
 
       {% include "includes/patient_nav.html" %}
 
-      <h2>Edit History for {{ patient.full_name }}</h2>
+      <h2>Edit History for {{ patient.full_name or patient.first_name }}</h2>
 
       <table class="table">
         <thead>

--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -24,10 +24,24 @@
         </tr>
 
         <tr>
+          <td>May 15 10:10am, 2015</td>
+          <td><a href="#">Mr. Beep Boop</a></td>
+          <td><a href="#">Crossover</a></td>
+          <td>Confirmed patient access.</td>
+        </tr>
+
+        <tr>
+          <td>April 01 11:20am, 2015</td>
+          <td><a href="#">Tulip</a></td>
+          <td><a href="#">Resource Centers</a></td>
+          <td>Shared patient with <a href="">Crossover</a></td>
+        </tr>
+
+        <tr>
           <td>April 01 11:15am, 2015</td>
           <td><a href="#">Tulip</a></td>
           <td><a href="#">Resource Centers</a></td>
-          <td>Updated primary phone number</td>
+          <td>Updated primary phone number from <code>(123) 345-7890</code> to <code>(123) 765-4321</code></td>
         </tr>
 
         <tr>

--- a/app/templates/includes/patient_household_size.html
+++ b/app/templates/includes/patient_household_size.html
@@ -12,7 +12,7 @@
       <th>Name</th>
       <th>DOB</th>
       <th>SSN</th>
-      <th>Relation</th>
+      <th>Relationship</th>
       <th>Edit</th>
       <th>Delete</th>
     </tr>
@@ -20,10 +20,10 @@
 
   <tr class="hh_member patient">
     <td class="hh_member_number">1</td>
-    <td class="hh_member_full_name">{{patient.full_name}}</td>
-    <td class="hh_member_dob">{{patient.dob}}</td>
-    <td class="hh_member_ssn">{{patient.ssn}}</td>
-    <td class="hh_member_relation">Patient</td>
+    <td class="hh_member_full_name">{{patient.full_name or patient.first_name or 'Patient'}}</td>
+    <td class="hh_member_dob">{{patient.dob or ''}}</td>
+    <td class="hh_member_ssn">{{patient.ssn or ''}}</td>
+    <td class="hh_member_relation">Self</td>
     <td class="hh_member_edit">
     </td>
   </tr>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -25,7 +25,7 @@
         <li class="patient-list-item clearfix col-sm-6 {% if loop.index < 3 %}new{% endif %} {% if loop.index == 3 %}recent{% endif %}">
           <h3 class="patient-name">{{ patient.full_name or patient.first_name }}</h3>
           <p class="patient-dob">DOB: {{ patient.dob }}</p>
-          <div class="completion-wrapper"><div class="completion high" style="width:{{ loop.index }}9%"></div></div><div class="completion-percentage">{{ loop.index }}9%</div>
+          <div class="completion-wrapper"><div class="completion high" style="width:{{ loop.index }}9%"></div></div><div class="completion-percentage">{{ loop.index }}9% completion</div>
           <p class="patient-lastedit left">Last edited by: <a href="#">____</a> at <a href="#">Richmond Resource Center</a></p>
           <a class="btn btn-default btn-sm right" href="{{ url_for('patient_details', id=patient.id) }}">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
         </li>

--- a/app/templates/patient_share.html
+++ b/app/templates/patient_share.html
@@ -4,7 +4,7 @@
 
       {% include "includes/patient_nav.html" %}
 
-      <h2>{{ patient.full_name }}</h2>
+      <h2>{{ patient.full_name or patient.first_name }}</h2>
       <p>Who would you like to share this information with?</p>
 
       <div class="col-sm-6 service">

--- a/app/utils.py
+++ b/app/utils.py
@@ -21,8 +21,8 @@ def send_document_image(file_name):
         pass
     else:
         return send_from_directory(os.path.join(
-            app.config['PROJECT_ROOT'],
-            app.config['UPLOAD_FOLDER']),
+            current_app.config['PROJECT_ROOT'],
+            current_app.config['UPLOAD_FOLDER']),
             file_name
         )
 


### PR DESCRIPTION
Closes #93, #94, and #95.

-You can now enter household member SSNs with dashes.
-Patient name appears correctly on edit history and sharing pages.
-Document image links on local, non-heroku version work again.

In the household members section:
    -The "Relation" column is now labeled "Relationship" as user suggested.
    -The relationship in the patient row is now "Self" instead of "Patient" as user suggested.
    -When the user hasn't entered a patient name yet, it appears as "Patient" rather than "None".
    -When the user hasn't entered a patient SSN/DOB yet, they appear blank rather than "None".
