### PR TITLE
switching to app factory & blueprint pattern

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --log-file=-
+web: gunicorn app:create_app\(\) --log-file=-

--- a/app/templates/consent.html
+++ b/app/templates/consent.html
@@ -5,7 +5,7 @@
     <div class="panel-heading"><h4>Almost there!</h4></div>
     <div class="panel-body">
       <p>In order to view this patient's information we need to make sure you have consent from them.</p>
-      <a class="btn btn-success" href="{{ url_for('patient_details', id=patient.id) }}" id="consent-button"><span class="glyphicon glyphicon-ok-circle"></span> CONSENT GIVEN</a>
+      <a class="btn btn-success" href="{{ url_for('screener.patient_details', id=patient.id) }}" id="consent-button"><span class="glyphicon glyphicon-ok-circle"></span> CONSENT GIVEN</a>
     </div>
   </div>
 

--- a/app/templates/includes/nav.html
+++ b/app/templates/includes/nav.html
@@ -14,13 +14,13 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="{{ url_for('new_prescreening') }}"><span class="glyphicon glyphicon-pencil push-right" aria-hidden="true"></span>Pre-Screener</a></li>
+        <li><a href="{{ url_for('screener.new_prescreening') }}"><span class="glyphicon glyphicon-pencil push-right" aria-hidden="true"></span>Pre-Screener</a></li>
         {% if g.user.is_authenticated() %}
-        <li><a href="{{ url_for('index') }}"><span class="glyphicon glyphicon-search push-right" aria-hidden="true"></span>Browse Patients</a></li>
-        <li><a href="{{ url_for('new_patient') }}"><span class="glyphicon glyphicon-plus push-right" aria-hidden="true"></span>Add Patient</a></li>
-        <li><a href="{{ url_for('logout') }}"><span class="glyphicon glyphicon-log-out push-right" aria-hidden="true"></span>Logout</a></li>
+        <li><a href="{{ url_for('screener.index') }}"><span class="glyphicon glyphicon-search push-right" aria-hidden="true"></span>Browse Patients</a></li>
+        <li><a href="{{ url_for('screener.new_patient') }}"><span class="glyphicon glyphicon-plus push-right" aria-hidden="true"></span>Add Patient</a></li>
+        <li><a href="{{ url_for('screener.logout') }}"><span class="glyphicon glyphicon-log-out push-right" aria-hidden="true"></span>Logout</a></li>
         {% else %}
-        <li><a href="{{ url_for('login') }}"><span class="glyphicon glyphicon-log-in push-right" aria-hidden="true"></span>Login</a></li>
+        <li><a href="{{ url_for('screener.login') }}"><span class="glyphicon glyphicon-log-in push-right" aria-hidden="true"></span>Login</a></li>
         {% endif %}
 
       </ul>

--- a/app/templates/includes/patient_docs.html
+++ b/app/templates/includes/patient_docs.html
@@ -21,7 +21,7 @@
           <img src="https://github.com/codeforamerica/rva-screening/blob/templating/images/w2.jpg?raw=true" alt="preview of {{doc.title}}">
         </td>
         <td class="patient_doc_title">
-          <a href="{{ url_for('document_image', image_id=doc.id) }}" class="read-only">
+          <a href="{{ url_for('screener.document_image', image_id=doc.id) }}" class="read-only">
             {{doc.description}}
           </a>
           <input type="text" class="hidden-input" name="document_image_description" value="{{doc.description}}">

--- a/app/templates/includes/patient_nav.html
+++ b/app/templates/includes/patient_nav.html
@@ -1,10 +1,10 @@
 <div class="patient-options">
-  <a class="btn btn-primary" href="{{ url_for('new_prescreening', patient_id=patient.id) }}">
+  <a class="btn btn-primary" href="{{ url_for('screener.new_prescreening', patient_id=patient.id) }}">
   <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span>
       Prescreen this patient
   </a>
 
-  <a class="btn btn-danger delete-patient right" href="{{ url_for('delete', id=patient.id) }}">
+  <a class="btn btn-danger delete-patient right" href="{{ url_for('screener.delete', id=patient.id) }}">
   <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
     Delete patient
   </a>
@@ -13,29 +13,29 @@
 <br>
 <ul class="patient-nav nav nav-tabs">
 
-  <li role="presentation" {% if request.path == url_for('patient_details', id=patient.id) %}class="active"{% endif %}>
-    <a href="{{ url_for('patient_details', id=patient.id) }}">
-    <span class="glyphicon glyphicon-user" aria-hidden="true"></span>  
+  <li role="presentation" {% if request.path == url_for('screener.patient_details', id=patient.id) %}class="active"{% endif %}>
+    <a href="{{ url_for('screener.patient_details', id=patient.id) }}">
+    <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
     Details
     </a>
   </li>
 
-  <li role="presentation" {% if request.path == url_for('patient_print', patient_id=patient.id) %}class="active"{% endif %}>
-    <a href="{{ url_for('patient_print', patient_id=patient.id) }}">
+  <li role="presentation" {% if request.path == url_for('screener.patient_print', patient_id=patient.id) %}class="active"{% endif %}>
+    <a href="{{ url_for('screener.patient_print', patient_id=patient.id) }}">
       <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
       Print this patient
     </a>
   </li>
 
-  <li role="presentation" {% if request.path == url_for('patient_history', patient_id=patient.id) %}class="active"{% endif %}>
-    <a href="{{ url_for('patient_history', patient_id=patient.id) }}">
-    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>  
+  <li role="presentation" {% if request.path == url_for('screener.patient_history', patient_id=patient.id) %}class="active"{% endif %}>
+    <a href="{{ url_for('screener.patient_history', patient_id=patient.id) }}">
+    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
       View Edit History
     </a>
   </li>
 
-  <li role="presentation" {% if request.path == url_for('patient_share', patient_id=patient.id) %}class="active"{% endif %}>
-    <a href="{{ url_for('patient_share', patient_id=patient.id) }}">
+  <li role="presentation" {% if request.path == url_for('screener.patient_share', patient_id=patient.id) %}class="active"{% endif %}>
+    <a href="{{ url_for('screener.patient_share', patient_id=patient.id) }}">
     <span class="glyphicon glyphicon-share-alt"></span>
       Share Patient
     </a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,7 @@
 {% block content %}
   <body>
 
-    <a href="{{ url_for('search_new') }}" class="btn btn-success right"><span class="glyphicon glyphicon-eye-open"></span> Search new patients</a>
+    <a href="{{ url_for('screener.search_new') }}" class="btn btn-success right"><span class="glyphicon glyphicon-eye-open"></span> Search new patients</a>
 
     <h1>RVA Screener</h1>
 
@@ -27,11 +27,11 @@
           <p class="patient-dob">DOB: {{ patient.dob }}</p>
           <div class="completion-wrapper"><div class="completion high" style="width:{{ loop.index }}9%"></div></div><div class="completion-percentage">{{ loop.index }}9% completion</div>
           <p class="patient-lastedit left">Last edited by: <a href="#">____</a> at <a href="#">Richmond Resource Center</a></p>
-          <a class="btn btn-default btn-sm right" href="{{ url_for('patient_details', id=patient.id) }}">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
+          <a class="btn btn-default btn-sm right" href="{{ url_for('screener.patient_details', id=patient.id) }}">Details <span class="glyphicon glyphicon-chevron-right"></span></a>
         </li>
         {% endfor %}
       </ul>
     <!-- /search -->
-    
+
   </body>
-{% endblock %}    
+{% endblock %}

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-	{% for service in services %}
+    {% for service in services %}
         <div class="service-pre-screen-result">
-    		{% if service.eligible %}
+            {% if service.eligible %}
                 <p class="alert alert-success">
                     <span class="glyphicon glyphicon-ok push-right"></span>
                     Good news!
                 </p>
-     			<h3>You are likely eligible for {{ service.name }}.</h3>
+                <h3>You are likely eligible for {{ service.name }}.</h3>
                 {% if service.general_fees %}
                     {% for fee in service.general_fees %}
                         <p>{{fee[0]}}: ${{fee[1]}}</p>
@@ -16,9 +16,9 @@
                 {% if service.name == 'Access Now' %}
                     Access Now's services are free.
                 {% endif %}
-     		{% else %}
-     			<h3>You are likely not eligible for {{ service.name }}.</h3>
-        	{% endif %}
+            {% else %}
+                <h3>You are likely not eligible for {{ service.name }}.</h3>
+            {% endif %}
             {% if service.sliding_scale %}
                 <h5>You're likely to fall in the {{service.sliding_scale}} section of the sliding scale.</h5>
                 {% if service.sliding_scale != 'Full fee' %}
@@ -31,14 +31,14 @@
     {% endfor %}
 
     {% if patient %}
-    	<a href="{{ url_for('save_prescreening_updates', patientid=patient.id) }}">
+        <a href="{{ url_for('screener.save_prescreening_updates', patientid=patient.id) }}">
         Return to details for {{ patient }}.
-    	</a>
+        </a>
 
  {#<!--    {% else %}
-    	<p>Would you save this information into a new patient record?</p>
-    	<a type="button" class="btn btn-success" href="{{ url_for('new_patient') }}">Yes</a>
-    	<a type="button" class="btn btn-default" href="{{ url_for('index') }}">No thanks</a> -->
+        <p>Would you save this information into a new patient record?</p>
+        <a type="button" class="btn btn-success" href="{{ url_for('screener.new_patient') }}">Yes</a>
+        <a type="button" class="btn btn-default" href="{{ url_for('screener.index') }}">No thanks</a> -->
  #}
     {% endif %}
 {% endblock %}

--- a/app/templates/search_new.html
+++ b/app/templates/search_new.html
@@ -10,7 +10,7 @@
 
       {% macro patient(name) %}
         <li class="patient-list-item col-sm-6">
-          <h3 class="patient-name">{{ name }} <a class="btn btn-default" href="{{ url_for('consent') }}">Add New Patient</a></h3>
+          <h3 class="patient-name">{{ name }} <a class="btn btn-default" href="{{ url_for('screener.consent') }}">Add New Patient</a></h3>
           <p class="patient-dob">DOB: xx/xx/xxxx</p>
           <p class="patient-lastedit">Associated with <a href="#">Richmond Resource Centers</a>, <a href="">Daily Planet</a></p>
         </li>
@@ -37,4 +37,4 @@
       </ul>
     <!-- /search -->
   </body>
-{% endblock %}    
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import os
 
 class Config(object):
+    DEBUG = True
     SECRET_KEY = 'some-secret'
     SCREENER_ENVIRONMENT = os.environ.get('SCREENER_ENVIRONMENT', 'dev')
     IS_PRODUCTION = os.environ.get('IS_PRODUCTION', False)
@@ -17,3 +18,13 @@ class Config(object):
     S3_FILE_UPLOAD_DIR = 'uploads'
     S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME', 'rva-screener')
     S3_ONLY_MODIFIED = False
+
+class ProdConfig(Config):
+    DEBUG = False
+
+class DevConfig(Config):
+    DEBUG = True
+
+class TestConfig(Config):
+    DEBUG = True
+    TESTING = True

--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
-from app import app
-app.debug = True
+from app import create_app
+from config import Config
+
+app = create_app(Config)
 app.run()


### PR DESCRIPTION
This switches to an [app factory model](http://flask.pocoo.org/docs/0.10/patterns/appfactories/) with [blueprints](http://flask.pocoo.org/docs/0.10/blueprints/), allowing us to switch config more easily during app instantiation (for testing, which is on another branch off of this one). This required the app to be namespaced (as `screener`) using blueprints, which allows us to create multiple apps if desired, so if there are additional components to be added later, they can have their own namespace.

This is all based on the recommendations of @bsmithgall, who pair programmed with me on this.
