### PR TITLE
adds `EXAMPLE` to global template context as shorthand for `app/example_data.py`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,12 +23,23 @@ login_manager.login_view = 'login'
 
 @app.context_processor
 def inject_static_url():
+    """Adds `STATIC_URL` variable to template context.
+    """
     static_url = os.environ.get('STATIC_URL', app.static_url_path)
     if not static_url.endswith('/'):
         static_url += '/'
     return dict(
         static_url=static_url
     )
+
+@app.context_processor
+def inject_example_data():
+    """Adds `EXAMPLE` variable to template context, if we need to fake data
+    somewhere.
+    """
+    from app import example_data
+    return dict(EXAMPLE=example_data)
+
 
 from app import views, models
 


### PR DESCRIPTION
This should allow for the easy use of fake data in templates for prototyping without touching any of the backend logic or adding anything to `views.py`. It also allows the faked data to be clearly marked in the template as example data using a big obvious capitalized variable name.

Here's what this would look like in `example_data.py`:

``` python
numbers = [1,4,5,6,7]
```

And here's what it would look like in a template:

``` jinja
      <ul>
        {% for number in EXAMPLE.numbers %}
        <li>{{number}}</li>
        {% endfor %}
      </ul>
```
