### PR TITLE
Prescreen updates

### DIFF
--- a/add_screening_criteria_data.py
+++ b/add_screening_criteria_data.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+import sys
+
+from flask import current_app
+from app import app
+from app.models import db, Service, SlidingScale, SlidingScaleFee
+
+def main():
+    with app.app_context():
+        db.metadata.create_all(db.engine)
+
+        daily_planet = Service(
+            name = 'Daily Planet',
+            fpl_cutoff = None,
+            uninsured_only_yn = 'N',
+            medicaid_ineligible_only_yn = 'N',
+            residence_requirement_yn = 'N',
+            time_in_area_requirement_yn = 'N',
+            sliding_scales = [
+                SlidingScale(
+                    scale_name = 'Nominal',
+                    fpl_low = 0,
+                    fpl_high = 100,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 30
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Slide A',
+                    fpl_low = 100,
+                    fpl_high = 125,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 45
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, second visit of calendar month',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Slide B',
+                    fpl_low = 125,
+                    fpl_high = 150,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 55
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 20
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 20
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, second visit of calendar month',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Slide C',
+                    fpl_low = 150,
+                    fpl_high = 200,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 65
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 30
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 30
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, second visit of calendar month',
+                            price_absolute = 25
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Full fee',
+                    fpl_low = 200,
+                    fpl_high = None
+                )
+            ]
+        )
+
+        crossover = Service(
+            name = 'CrossOver',
+            fpl_cutoff = 200,
+            uninsured_only_yn = 'Y',
+            medicaid_ineligible_only_yn = 'N',
+            residence_requirement_yn = 'N',
+            time_in_area_requirement_yn = 'N',
+            sliding_scales = [
+                SlidingScale(
+                    scale_name = 'All',
+                    fpl_low = 0,
+                    fpl_high = None,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Medications',
+                            price_absolute = 4
+                        ),
+                        SlidingScaleFee(
+                            name = 'Nurse/Labs',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Vaccine clinic',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical visit/mental health',
+                            price_absolute = 55
+                        ),
+                        SlidingScaleFee(
+                            name = 'Eye',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Same day appointments',
+                            price_absolute = 20
+                        ),
+                        SlidingScaleFee(
+                            name = 'Dental',
+                            price_absolute = 20
+                        )
+                    ]
+                )
+            ]
+        )
+
+        access_now = Service(
+            name = 'Access Now',
+            fpl_cutoff = 200,
+            uninsured_only_yn = 'Y',
+            medicaid_ineligible_only_yn = 'Y',
+            residence_requirement_yn = 'Y',
+            time_in_area_requirement_yn = 'Y',
+        )
+
+        resource_centers = Service(
+            name = 'RCHD Resource Centers',
+            fpl_cutoff = None,
+            uninsured_only_yn = 'N',
+            medicaid_ineligible_only_yn = 'N',
+            residence_requirement_yn = 'N',
+            time_in_area_requirement_yn = 'N',
+            sliding_scales = [
+                SlidingScale(
+                    scale_name = 'A',
+                    fpl_low = 0,
+                    fpl_high = 80,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 0
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'B',
+                    fpl_low = 80,
+                    fpl_high = 88,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 10
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'C',
+                    fpl_low = 88,
+                    fpl_high = 106.6,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 25
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'D',
+                    fpl_low = 106.6,
+                    fpl_high = 133.2,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 50
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'E',
+                    fpl_low = 133.2,
+                    fpl_high = 160,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 75
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'F',
+                    fpl_low = 160,
+                    fpl_high = 200,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 95
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'G',
+                    fpl_low = 200,
+                    fpl_high = None,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 100
+                        )
+                    ]
+                ),               
+            ]
+        )
+
+
+        db.session.add_all([daily_planet, crossover, access_now, resource_centers])
+        db.session.commit()
+        print 'Service eligibility and sliding scale data added.'
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/add_screening_criteria_data.py
+++ b/add_screening_criteria_data.py
@@ -156,7 +156,7 @@ def main():
                         ),
                         SlidingScaleFee(
                             name = 'Medical visit/mental health',
-                            price_absolute = 55
+                            price_absolute = 15
                         ),
                         SlidingScaleFee(
                             name = 'Eye',

--- a/app/models.py
+++ b/app/models.py
@@ -137,6 +137,27 @@ class Insurance(db.Model):
 class Service(db.Model):
   id = db.Column(db.Integer, primary_key=True)
   name = db.Column(db.String(64))
+  fpl_cutoff = db.Column(db.Integer)
+  uninsured_only_yn = db.Column(db.String(1))
+  medicaid_ineligible_only_yn = db.Column(db.String(1))
+  residence_requirement_yn = db.Column(db.String(1))
+  time_in_area_requirement_yn = db.Column(db.String(1))
+  sliding_scales = db.relationship('SlidingScale', backref='service', lazy='dynamic')
+
+class SlidingScale(db.Model):
+  id = db.Column(db.Integer, primary_key=True)
+  service_id = db.Column(db.Integer, db.ForeignKey("service.id"))
+  scale_name = db.Column(db.String(64))
+  fpl_low = db.Column(db.Float)
+  fpl_high = db.Column(db.Float)
+  sliding_scale_fees = db.relationship('SlidingScaleFee', backref='slidingscale', lazy='dynamic')
+
+class SlidingScaleFee(db.Model):
+  id = db.Column(db.Integer, primary_key=True)
+  sliding_scale_id = db.Column(db.Integer, db.ForeignKey("sliding_scale.id"))
+  name = db.Column(db.String(128))
+  price_absolute = db.Column(db.Integer)
+  price_percentage = db.Column(db.Integer)
 
 class User(db.Model):
   id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/new_prescreening.html
+++ b/app/templates/new_prescreening.html
@@ -5,33 +5,14 @@
 
     <form method="post">
     
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="resource_centers" name="services" checked="true">
-          Resource centers
-        </label>
-      </div>
-
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="cross_over" name="services" checked="true">
-          Cross Over
-        </label>
-      </div>
-
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="daily_planet" name="services" checked="true">
-          Daily Planet
-        </label>
-      </div>
-
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="access_now" name="services" checked="true">
-          Access Now
-        </label>
-      </div>
+      {% for service in services %}
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" class="text" value="{{service.id}}" name="services" checked="true">
+            {{service.name}}
+          </label>
+        </div>
+      {% endfor %}
 
       <button class="btn btn-primary"  type="submit">Check eligibility</button>       
     </form>

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
     
-    <h4 class="prescreen-title">Patient Inputs</h4>
+    <h4 class="prescreen-title">Patient Inputs <a style="font-size:.6em;" href="#"><span class="glyphicon glyphicon-edit push-left"></span> Edit Inputs</a></h4>
     <div class="row prescreen-user-info">
         <div class="col-sm-3 prescreen-user-info-item">
             <p>Annual household income</p>
@@ -31,6 +31,7 @@
                 {% else %}
                     You are likely not eligible for <strong>{{ service.name }}</strong>.
                 {% endif %}
+                <a class="btn btn-default btn-sm pull-right" href="#">More about <strong>{{ service.name }}</strong> <span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
 
             <div class="row prescreen-service-info">

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,26 +1,34 @@
 {% extends "base.html" %}
 {% block content %}
     
-    <h4 class="prescreen-title">Patient Inputs <a style="font-size:.6em;" href="#"><span class="glyphicon glyphicon-edit push-left"></span> Edit Inputs</a></h4>
+    <h4 class="prescreen-title">Patient Information <a style="font-size:.6em;" href="#"><span class="glyphicon glyphicon-edit push-left"></span> Edit</a></h4>
+    
     <div class="row prescreen-user-info">
+
+        <div class="col-sm-3 prescreen-user-info-item first">
+            <p>Federal Poverty Level percentage</p>
+            <h2>{{fpl | int}}%</h2>
+        </div>
+
         <div class="col-sm-3 prescreen-user-info-item">
             <p>Annual household income</p>
             <h2>${{household_income}}</h2>
         </div>
-        <div class="col-sm-3 prescreen-user-info-item">
+        <div class="col-sm-2 prescreen-user-info-item">
             <p>Household size</p>
             <h2>{{household_size}}</h2>
         </div>
-        <div class="col-sm-3 prescreen-user-info-item">
+        <div class="col-sm-2 prescreen-user-info-item">
             <p>Has insurance</p>
             <h2>{{has_health_insurance}}</h2>
         </div>
-        <div class="col-sm-3 prescreen-user-info-item">
+        <div class="col-sm-2 prescreen-user-info-item">
             <p>Eligible for Medicaid</p>
             <h2>{{is_eligible_for_medicaid}}</h2>
         </div>
     </div>
-    <h4>Federal Poverty Level percentage: {{fpl | int}}%</h4>
+
+    <h4 class="prescreen-title">Services</h4>
     
     {% for service in services %}
         <div class="prescreen-service row {% if service.eligible %}eligible{% else %}not-eligible{% endif %}">
@@ -68,15 +76,15 @@
                             Not eligible for Medicaid
                         </div>
                     {% endif %}
-                </div>
-                <div class="col-sm-8">
+                
                     {% if service.eligible and service.sliding_scale %}
                         {% if service.sliding_scale != 'All' %}
                             <p>You're likely to fall in the <strong>{{service.sliding_scale}}</strong> section of the sliding scale because your income is <strong>{{service.sliding_scale_range}}</strong> of the Federal Poverty Level.</p>
                         {% else %}
                             <p>Service fees:</p>
                         {% endif %}
-
+                </div>
+                <div class="col-sm-8">
                         {% if service.sliding_scale != 'Full fee' %}
                             <div class="prescreen-service-items">
                                 {% for fee in service.sliding_scale_fees %}

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -3,7 +3,7 @@
     
     <h4 class="prescreen-title">Patient Information <a style="font-size:.6em;" href="#"><span class="glyphicon glyphicon-edit push-left"></span> Edit</a></h4>
     
-    <div class="row prescreen-user-info">
+    <div class="prescreen-user-info">
 
         <div class="col-sm-3 prescreen-user-info-item first">
             <p>Federal Poverty Level percentage</p>
@@ -31,7 +31,7 @@
     <h4 class="prescreen-title">Services</h4>
     
     {% for service in services %}
-        <div class="prescreen-service row {% if service.eligible %}eligible{% else %}not-eligible{% endif %}">
+        <div class="prescreen-service {% if service.eligible %}eligible{% else %}not-eligible{% endif %}">
             
             <div class="prescreen-service-title">
                 {% if service.eligible %}

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
     <p>Your input:</p>
-    <p>${{household_income}} annual income for {{household_size}} household members = {{fpl | int}}% of the Federal Poverty Level</p>
-    <p>Has insurance: {{has_health_insurance}}</p>
-    <p>Eligible for Medicaid: {{is_eligible_for_medicaid}}</p>
+    <ul>
+        <li>Annual household income: ${{household_income}}</li>
+        <li>Household size: {{household_size}}</li>
+        <li>Has insurance: {{has_health_insurance}}</li>
+        <li>Eligible for Medicaid: {{is_eligible_for_medicaid}}</li>
+    </ul>
+    <h4>Federal Poverty Level percentage: {{fpl | int}}%</h4>
     {% for service in services %}
         <div class="service-pre-screen-result">
             <div 

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,87 +1,107 @@
 {% extends "base.html" %}
 {% block content %}
-    <p>Your input:</p>
-    <ul>
-        <li>Annual household income: ${{household_income}}</li>
-        <li>Household size: {{household_size}}</li>
-        <li>Has insurance: {{has_health_insurance}}</li>
-        <li>Eligible for Medicaid: {{is_eligible_for_medicaid}}</li>
-    </ul>
+    
+    <h4 class="prescreen-title">Patient Inputs</h4>
+    <div class="row prescreen-user-info">
+        <div class="col-sm-3 prescreen-user-info-item">
+            <p>Annual household income</p>
+            <h2>${{household_income}}</h2>
+        </div>
+        <div class="col-sm-3 prescreen-user-info-item">
+            <p>Household size</p>
+            <h2>{{household_size}}</h2>
+        </div>
+        <div class="col-sm-3 prescreen-user-info-item">
+            <p>Has insurance</p>
+            <h2>{{has_health_insurance}}</h2>
+        </div>
+        <div class="col-sm-3 prescreen-user-info-item">
+            <p>Eligible for Medicaid</p>
+            <h2>{{is_eligible_for_medicaid}}</h2>
+        </div>
+    </div>
     <h4>Federal Poverty Level percentage: {{fpl | int}}%</h4>
+    
     {% for service in services %}
-        <div class="service-pre-screen-result">
-            <div 
+        <div class="prescreen-service row {% if service.eligible %}eligible{% else %}not-eligible{% endif %}">
+            
+            <div class="prescreen-service-title">
                 {% if service.eligible %}
-                    class="alert alert-success"
+                    You are likely eligible for <strong>{{ service.name }}</strong>.
                 {% else %}
-                    class="alert alert-danger"
-                {% endif %}
-            >
-                {% if service.eligible %}
-                    <h4>You are likely eligible for {{ service.name }}.</h4>
-                {% else %}
-                    <h4>You are likely not eligible for {{ service.name }}.</h4>
-                {% endif %}
-                {% if service.fpl_cutoff %}
-                    <div>
-                        {% if service.fpl_eligible %}
-                            <span class="glyphicon glyphicon-ok push-right"></span>
-                        {% else %}
-                            <span class="glyphicon glyphicon-remove push-right"></span>
-                        {% endif %}
-                        Income below {{service.fpl_cutoff}}% of the Federal Poverty Level
-                    </div>
-                {% endif %}
-                {% if service.uninsured_only_yn == 'Y' %}
-                    <div>
-                        {% if has_health_insurance == 'no' %}
-                            <span class="glyphicon glyphicon-ok push-right"></span>
-                        {% else %}
-                            <span class="glyphicon glyphicon-remove push-right"></span>
-                        {% endif %}
-                        Uninsured
-                    </div>
-                {% endif %}
-                {% if service.medicaid_ineligible_only_yn == 'Y' %}
-                    <div>
-                        {% if is_eligible_for_medicaid == 'no' %}
-                            <span class="glyphicon glyphicon-ok push-right"></span>
-                        {% else %}
-                            <span class="glyphicon glyphicon-remove push-right"></span>
-                        {% endif %}
-                        Not eligible for Medicaid
-                    </div>
+                    You are likely not eligible for <strong>{{ service.name }}</strong>.
                 {% endif %}
             </div>
 
-            {% if service.eligible and service.sliding_scale %}
-                {% if service.sliding_scale != 'All' %}
-                    <p>You're likely to fall in the <strong>{{service.sliding_scale}}</strong> section of the sliding scale because your income is <strong>{{service.sliding_scale_range}}</strong> of the Federal Poverty Level.</p>
-                {% else %}
-                    <p>Service fees:</p>
-                {% endif %}
-
-                {% if service.sliding_scale != 'Full fee' %}
-                    <ul>
-                        {% for fee in service.sliding_scale_fees %}
-                            {% if fee.price_absolute %}
-                                <li>{{fee.name}}: ${{fee.price_absolute}}</li>
+            <div class="row prescreen-service-info">
+                <div class="col-sm-4">
+                    {% if service.fpl_cutoff %}
+                        <div>
+                            {% if service.fpl_eligible %}
+                                <span class="glyphicon glyphicon-ok push-right"></span>
                             {% else %}
-                                <li>{{fee.name}}: {{fee.price_percentage}}% of full price</li>
+                                <span class="glyphicon glyphicon-remove push-right"></span>
                             {% endif %}
+                            Income below {{service.fpl_cutoff}}% of the Federal Poverty Level
+                        </div>
+                    {% endif %}
+
+                    {% if service.uninsured_only_yn == 'Y' %}
+                        <div>
+                            {% if has_health_insurance == 'no' %}
+                                <span class="glyphicon glyphicon-ok push-right"></span>
+                            {% else %}
+                                <span class="glyphicon glyphicon-remove push-right"></span>
+                            {% endif %}
+                            Uninsured
+                        </div>
+                    {% endif %}
+
+                    {% if service.medicaid_ineligible_only_yn == 'Y' %}
+                        <div>
+                            {% if is_eligible_for_medicaid == 'no' %}
+                                <span class="glyphicon glyphicon-ok push-right"></span>
+                            {% else %}
+                                <span class="glyphicon glyphicon-remove push-right"></span>
+                            {% endif %}
+                            Not eligible for Medicaid
+                        </div>
+                    {% endif %}
+                </div>
+                <div class="col-sm-8">
+                    {% if service.eligible and service.sliding_scale %}
+                        {% if service.sliding_scale != 'All' %}
+                            <p>You're likely to fall in the <strong>{{service.sliding_scale}}</strong> section of the sliding scale because your income is <strong>{{service.sliding_scale_range}}</strong> of the Federal Poverty Level.</p>
+                        {% else %}
+                            <p>Service fees:</p>
+                        {% endif %}
+
+                        {% if service.sliding_scale != 'Full fee' %}
+                            <div class="prescreen-service-items">
+                                {% for fee in service.sliding_scale_fees %}
+                                    {% if fee.price_absolute %}
+                                        <div class="item">{{fee.name}}: <span class="item-price"><strong>${{fee.price_absolute}}</strong><span></div>
+                                    {% else %}
+                                        <div class="item">{{fee.name}}: <span class="item-price"><strong>{{fee.price_percentage}}%</strong><span> of full price</div>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    {% endif %}
+
+                    {% if service.eligible and service.general_fees %}
+                        {% for fee in service.general_fees %}
+                            <p>{{fee[0]}}: ${{fee[1]}}</p>
                         {% endfor %}
-                    </ul>
-                {% endif %}
-            {% endif %}
-            {% if service.eligible and service.general_fees %}
-                {% for fee in service.general_fees %}
-                    <p>{{fee[0]}}: ${{fee[1]}}</p>
-                {% endfor %}
-            {% endif %}
-            {% if service.eligible and service.name == 'Access Now' %}
-                Access Now provides service at no cost to the patient.
-            {% endif %}
-        </div>
+                    {% endif %}
+
+                    {% if service.eligible and service.name == 'Access Now' %}
+                        Access Now provides service at no cost to the patient.
+                    {% endif %}
+                </div>
+
+            </div><!-- .prescreen-service-info -->
+        </div><!-- .prescreen-service -->
     {% endfor %}
 
     {% if patient %}

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -3,7 +3,7 @@
     
     <h4 class="prescreen-title">Patient Information <a style="font-size:.6em;" href="#"><span class="glyphicon glyphicon-edit push-left"></span> Edit</a></h4>
     
-    <div class="prescreen-user-info">
+    <div class="prescreen-user-info clearfix">
 
         <div class="col-sm-3 prescreen-user-info-item first">
             <p>Federal Poverty Level percentage</p>

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,31 +1,81 @@
 {% extends "base.html" %}
 {% block content %}
-	{% for service in services %}
+    <p>Your input:</p>
+    <p>${{household_income}} annual income for {{household_size}} household members = {{fpl | int}}% of the Federal Poverty Level</p>
+    <p>Has insurance: {{has_health_insurance}}</p>
+    <p>Eligible for Medicaid: {{is_eligible_for_medicaid}}</p>
+    {% for service in services %}
         <div class="service-pre-screen-result">
-    		{% if service.eligible %}
-                <p class="alert alert-success">
-                    <span class="glyphicon glyphicon-ok push-right"></span>
-                    Good news!
-                </p>
-     			<h3>You are likely eligible for {{ service.name }}.</h3>
-                {% if service.general_fees %}
-                    {% for fee in service.general_fees %}
-                        <p>{{fee[0]}}: ${{fee[1]}}</p>
-                    {% endfor %}
+            <div 
+                {% if service.eligible %}
+                    class="alert alert-success"
+                {% else %}
+                    class="alert alert-danger"
                 {% endif %}
-                {% if service.name == 'Access Now' %}
-                    Access Now's services are free.
+            >
+                {% if service.eligible %}
+                    <h4>You are likely eligible for {{ service.name }}.</h4>
+                {% else %}
+                    <h4>You are likely not eligible for {{ service.name }}.</h4>
                 {% endif %}
-     		{% else %}
-     			<h3>You are likely not eligible for {{ service.name }}.</h3>
-        	{% endif %}
-            {% if service.sliding_scale %}
-                <h5>You're likely to fall in the {{service.sliding_scale}} section of the sliding scale.</h5>
+                {% if service.fpl_cutoff %}
+                    <div>
+                        {% if service.fpl_eligible %}
+                            <span class="glyphicon glyphicon-ok push-right"></span>
+                        {% else %}
+                            <span class="glyphicon glyphicon-remove push-right"></span>
+                        {% endif %}
+                        Income below {{service.fpl_cutoff}}% of the Federal Poverty Level
+                    </div>
+                {% endif %}
+                {% if service.uninsured_only_yn == 'Y' %}
+                    <div>
+                        {% if has_health_insurance == 'no' %}
+                            <span class="glyphicon glyphicon-ok push-right"></span>
+                        {% else %}
+                            <span class="glyphicon glyphicon-remove push-right"></span>
+                        {% endif %}
+                        Uninsured
+                    </div>
+                {% endif %}
+                {% if service.medicaid_ineligible_only_yn == 'Y' %}
+                    <div>
+                        {% if is_eligible_for_medicaid == 'no' %}
+                            <span class="glyphicon glyphicon-ok push-right"></span>
+                        {% else %}
+                            <span class="glyphicon glyphicon-remove push-right"></span>
+                        {% endif %}
+                        Not eligible for Medicaid
+                    </div>
+                {% endif %}
+            </div>
+
+            {% if service.eligible and service.sliding_scale %}
+                {% if service.sliding_scale != 'All' %}
+                    <p>You're likely to fall in the <strong>{{service.sliding_scale}}</strong> section of the sliding scale because your income is <strong>{{service.sliding_scale_range}}</strong> of the Federal Poverty Level.</p>
+                {% else %}
+                    <p>Service fees:</p>
+                {% endif %}
+
                 {% if service.sliding_scale != 'Full fee' %}
-                    {% for fee in service.sliding_scale_fees %}
-                        <p>{{fee[0]}}: ${{fee[1]}}</p>
-                    {% endfor %}
+                    <ul>
+                        {% for fee in service.sliding_scale_fees %}
+                            {% if fee.price_absolute %}
+                                <li>{{fee.name}}: ${{fee.price_absolute}}</li>
+                            {% else %}
+                                <li>{{fee.name}}: {{fee.price_percentage}}% of full price</li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
                 {% endif %}
+            {% endif %}
+            {% if service.eligible and service.general_fees %}
+                {% for fee in service.general_fees %}
+                    <p>{{fee[0]}}: ${{fee[1]}}</p>
+                {% endfor %}
+            {% endif %}
+            {% if service.eligible and service.name == 'Access Now' %}
+                Access Now provides service at no cost to the patient.
             {% endif %}
         </div>
     {% endfor %}

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -39,7 +39,7 @@
                 {% else %}
                     You are likely not eligible for <strong>{{ service.name }}</strong>.
                 {% endif %}
-                <a class="btn btn-default btn-sm pull-right" href="#">More about <strong>{{ service.name }}</strong> <span class="glyphicon glyphicon-chevron-right"></span></a>
+                <a class="btn btn-default btn-sm pull-right-desktop" href="#">More about <strong>{{ service.name }}</strong> <span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
 
             <div class="row prescreen-service-info">
@@ -91,7 +91,7 @@
                                     {% if fee.price_absolute %}
                                         <div class="item">{{fee.name}}: <span class="item-price"><strong>${{fee.price_absolute}}</strong><span></div>
                                     {% else %}
-                                        <div class="item">{{fee.name}}: <span class="item-price"><strong>{{fee.price_percentage}}%</strong><span> of full price</div>
+                                        <div class="item">{{fee.name}}: <span class="item-price pull-right-desktop"><strong>{{fee.price_percentage}}%</strong><span> of full price</div>
                                     {% endif %}
                                 {% endfor %}
                             </div>

--- a/front/sass/_base.scss
+++ b/front/sass/_base.scss
@@ -188,9 +188,13 @@ body {
   .prescreen-user-info-item {
     text-align:center;
 
+    @media screen and (min-width: 768px) {
+      &.first {
+        text-align:right;
+        border-right:1px solid #c0c0c0;
+      }
+    }
     &.first {
-      text-align:right;
-      border-right:1px solid #c0c0c0;
       h2 {
         color:#0074D9;
       }

--- a/front/sass/_base.scss
+++ b/front/sass/_base.scss
@@ -172,6 +172,83 @@ body {
  *
  *
  */
+@mixin title {
+  text-transform:uppercase;
+  letter-spacing:.1em;
+}
+.prescreen-title {
+  text-transform: uppercase;
+  text-align: center;
+  color:steelblue;
+}
+.prescreen-user-info {
+  .prescreen-user-info-item {
+    background:white;
+    padding:1em;
+    border-right:2px solid #f6f6f6;
+    text-align:center;
+    p {
+      @include title;
+      font-size:.8em;
+      color:#999;
+      margin:0;
+      padding:0;
+    }
+    h2 {
+      text-transform:uppercase;
+      font-weight:900;
+      margin:0;
+      padding:0;
+    }
+  }
+}
+
+.prescreen-service {
+  background:white;
+  margin-bottom:1em;
+  
+  .prescreen-service-title {
+    padding:.5em 1em;
+    font-size:1.5em;
+    font-weight:300; 
+  }
+
+  &.eligible {
+    .prescreen-service-title {
+      color:#2ECC40;
+      border-bottom:1px solid #2ECC40;
+    }
+  }
+
+  &.not-eligible {
+    .prescreen-service-title {
+      color:#AAAAAA;
+      border-bottom:1px solid #AAAAAA;
+    }
+  }
+
+  .prescreen-service-info {
+    padding:1em;
+  }
+
+  .prescreen-service-items {
+    .item {
+      padding:.6em 1em;
+      font-size:.9em;
+      &:nth-child(2n-1) {
+        background-color:#f6f6f6;
+      }
+      @include title;
+      .item-price {
+        font-size:1.2em;
+        color:#3D9970;
+        float:right;
+      }
+    }
+  }
+}
+
+
 .pre-screeners {}
 .pre-screener-option {
   padding:1.2em;

--- a/front/sass/_base.scss
+++ b/front/sass/_base.scss
@@ -13,6 +13,11 @@ body {
 .push-right { /* used mostly with icons */
   margin-right:.5em;
 }
+.pull-right-desktop {
+  @media screen and (min-width: 768px) {
+    float:right;
+  }
+}
 
 
 /* MENU
@@ -270,7 +275,6 @@ body {
       .item-price {
         font-size:1.2em;
         color:#3D9970;
-        float:right;
       }
     }
   }

--- a/front/sass/_base.scss
+++ b/front/sass/_base.scss
@@ -178,27 +178,50 @@ body {
 }
 .prescreen-title {
   text-transform: uppercase;
-  text-align: center;
-  color:steelblue;
+  margin-top:2em;
 }
 .prescreen-user-info {
+  margin-bottom:1em;
+  background:white;
+  padding:1em;
+  
   .prescreen-user-info-item {
-    background:white;
-    padding:1em;
-    border-right:2px solid #f6f6f6;
     text-align:center;
+
+    &.first {
+      text-align:right;
+      border-right:1px solid #c0c0c0;
+      h2 {
+        color:#0074D9;
+      }
+    }
+    
     p {
       @include title;
       font-size:.8em;
-      color:#999;
+      color:#c0c0c0;
       margin:0;
       padding:0;
     }
+
     h2 {
+      color:#333;
       text-transform:uppercase;
       font-weight:900;
+      font-size:1.3em;
+      letter-spacing:.1em;
       margin:0;
       padding:0;
+    }
+  }
+
+  .prescreen-fpl {
+    border:1px solid #c0c0c0;
+    font-size:1.5em;
+    font-weight:300;
+    padding:1em;
+    strong {
+      // color:#333;
     }
   }
 }

--- a/front/sass/_base.scss
+++ b/front/sass/_base.scss
@@ -208,22 +208,23 @@ body {
   margin-bottom:1em;
   
   .prescreen-service-title {
-    padding:.5em 1em;
+    padding:.5em;
     font-size:1.5em;
-    font-weight:300; 
+    font-weight:300;
+    border-bottom:1px solid #c0c0c0;
   }
 
   &.eligible {
+    border-left:5px solid #2ECC40;
     .prescreen-service-title {
       color:#2ECC40;
-      border-bottom:1px solid #2ECC40;
     }
   }
 
   &.not-eligible {
+    border-left:5px solid #AAAAAA;
     .prescreen-service-title {
       color:#AAAAAA;
-      border-bottom:1px solid #AAAAAA;
     }
   }
 


### PR DESCRIPTION
- Adds database tables to store information about each service's criteria and sliding scale fees.
- add_screening_criteria_data.py adds the data we currently have (which has lots of holes to fill in). This resolves #108.
- Adds information to the prescreening results about the patient's FPL, which criteria the patient does/does not meet for each service, and in the case of a sliding scale, the FPL range for the section the patient falls in. Resolves #66.
- Shows the user's input on the results page. Not sure if this is helpful--we can remove it if not, but figured I'd put it there now for experimentation.
- The sliding_scale_fee table has separate fields for absolute prices and prices that are a percentage of the full price, so we can display them accordingly. Fixes #124.

It's not very pretty right now:
![screen shot 2015-05-28 at 11 45 05 am](https://cloud.githubusercontent.com/assets/1129130/7864270/1e79f688-052f-11e5-8014-9bb076a681a3.png)
