### PR TITLE
Service permissions

### DIFF
--- a/add_screening_criteria_data.py
+++ b/add_screening_criteria_data.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+import sys
+
+from flask import current_app
+from app import app
+from app.models import db, Service, SlidingScale, SlidingScaleFee
+
+def main():
+    with app.app_context():
+        db.metadata.create_all(db.engine)
+
+        daily_planet = Service(
+            name = 'Daily Planet',
+            fpl_cutoff = None,
+            uninsured_only_yn = 'N',
+            medicaid_ineligible_only_yn = 'N',
+            residence_requirement_yn = 'N',
+            time_in_area_requirement_yn = 'N',
+            sliding_scales = [
+                SlidingScale(
+                    scale_name = 'Nominal',
+                    fpl_low = 0,
+                    fpl_high = 100,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 30
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Slide A',
+                    fpl_low = 100,
+                    fpl_high = 125,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 45
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, second visit of calendar month',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Slide B',
+                    fpl_low = 125,
+                    fpl_high = 150,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 55
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 20
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 20
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, second visit of calendar month',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Slide C',
+                    fpl_low = 150,
+                    fpl_high = 200,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Dental services',
+                            price_percentage = 65
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical services',
+                            price_absolute = 30
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, initial visit of calendar month',
+                            price_absolute = 30
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, second visit of calendar month',
+                            price_absolute = 25
+                        ),
+                        SlidingScaleFee(
+                            name = 'Mental health services, other visits',
+                            price_absolute = 5
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'Full fee',
+                    fpl_low = 200,
+                    fpl_high = None
+                )
+            ]
+        )
+
+        crossover = Service(
+            name = 'CrossOver',
+            fpl_cutoff = 200,
+            uninsured_only_yn = 'Y',
+            medicaid_ineligible_only_yn = 'N',
+            residence_requirement_yn = 'N',
+            time_in_area_requirement_yn = 'N',
+            sliding_scales = [
+                SlidingScale(
+                    scale_name = 'All',
+                    fpl_low = 0,
+                    fpl_high = None,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'Medications',
+                            price_absolute = 4
+                        ),
+                        SlidingScaleFee(
+                            name = 'Nurse/Labs',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Vaccine clinic',
+                            price_absolute = 10
+                        ),
+                        SlidingScaleFee(
+                            name = 'Medical visit/mental health',
+                            price_absolute = 55
+                        ),
+                        SlidingScaleFee(
+                            name = 'Eye',
+                            price_absolute = 15
+                        ),
+                        SlidingScaleFee(
+                            name = 'Same day appointments',
+                            price_absolute = 20
+                        ),
+                        SlidingScaleFee(
+                            name = 'Dental',
+                            price_absolute = 20
+                        )
+                    ]
+                )
+            ]
+        )
+
+        access_now = Service(
+            name = 'Access Now',
+            fpl_cutoff = 200,
+            uninsured_only_yn = 'Y',
+            medicaid_ineligible_only_yn = 'Y',
+            residence_requirement_yn = 'Y',
+            time_in_area_requirement_yn = 'Y',
+        )
+
+        resource_centers = Service(
+            name = 'RCHD Resource Centers',
+            fpl_cutoff = None,
+            uninsured_only_yn = 'N',
+            medicaid_ineligible_only_yn = 'N',
+            residence_requirement_yn = 'N',
+            time_in_area_requirement_yn = 'N',
+            sliding_scales = [
+                SlidingScale(
+                    scale_name = 'A',
+                    fpl_low = 0,
+                    fpl_high = 80,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 0
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'B',
+                    fpl_low = 80,
+                    fpl_high = 88,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 10
+                        )
+                    ]
+                ),
+                SlidingScale(
+                    scale_name = 'C',
+                    fpl_low = 88,
+                    fpl_high = 106.6,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 25
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'D',
+                    fpl_low = 106.6,
+                    fpl_high = 133.2,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 50
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'E',
+                    fpl_low = 133.2,
+                    fpl_high = 160,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 75
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'F',
+                    fpl_low = 160,
+                    fpl_high = 200,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 95
+                        )
+                    ]
+                ),  
+                SlidingScale(
+                    scale_name = 'G',
+                    fpl_low = 200,
+                    fpl_high = None,
+                    sliding_scale_fees = [
+                        SlidingScaleFee(
+                            name = 'All services',
+                            price_percentage = 100
+                        )
+                    ]
+                ),               
+            ]
+        )
+
+
+        db.session.add_all([daily_planet, crossover, access_now, resource_centers])
+        db.session.commit()
+        print 'Service eligibility and sliding scale data added.'
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/add_screening_criteria_data.py
+++ b/add_screening_criteria_data.py
@@ -156,7 +156,7 @@ def main():
                         ),
                         SlidingScaleFee(
                             name = 'Medical visit/mental health',
-                            price_absolute = 55
+                            price_absolute = 15
                         ),
                         SlidingScaleFee(
                             name = 'Eye',

--- a/app/models.py
+++ b/app/models.py
@@ -75,7 +75,8 @@ class Patient(db.Model):
   fpl_percentage = 0
 
   # Permissions
-  patient_service_permissions = db.relationship('PatientServicePermission', backref='patient', lazy='dynamic')
+  #patient_service_permissions = db.relationship('PatientServicePermission', backref='patient', lazy='dynamic')
+  services = db.relationship('Service', secondary='patient_service_permission')
 
   def __init__(self, **fields):
     self.__dict__.update(fields)

--- a/app/models.py
+++ b/app/models.py
@@ -74,6 +74,9 @@ class Patient(db.Model):
   total_annual_income = 0
   fpl_percentage = 0
 
+  # Permissions
+  patient_service_permissions = db.relationship('PatientServicePermission', backref='patient', lazy='dynamic')
+
   def __init__(self, **fields):
     self.__dict__.update(fields)
 
@@ -158,6 +161,11 @@ class SlidingScaleFee(db.Model):
   name = db.Column(db.String(128))
   price_absolute = db.Column(db.Integer)
   price_percentage = db.Column(db.Integer)
+
+class PatientServicePermission(db.Model):
+  id = db.Column(db.Integer, primary_key=True)
+  patient_id = db.Column(db.Integer, db.ForeignKey("patient.id"))
+  service_id = db.Column(db.Integer, db.ForeignKey("service.id"))
 
 class User(db.Model):
   id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -137,6 +137,27 @@ class Insurance(db.Model):
 class Service(db.Model):
   id = db.Column(db.Integer, primary_key=True)
   name = db.Column(db.String(64))
+  fpl_cutoff = db.Column(db.Integer)
+  uninsured_only_yn = db.Column(db.String(1))
+  medicaid_ineligible_only_yn = db.Column(db.String(1))
+  residence_requirement_yn = db.Column(db.String(1))
+  time_in_area_requirement_yn = db.Column(db.String(1))
+  sliding_scales = db.relationship('SlidingScale', backref='service', lazy='dynamic')
+
+class SlidingScale(db.Model):
+  id = db.Column(db.Integer, primary_key=True)
+  service_id = db.Column(db.Integer, db.ForeignKey("service.id"))
+  scale_name = db.Column(db.String(64))
+  fpl_low = db.Column(db.Float)
+  fpl_high = db.Column(db.Float)
+  sliding_scale_fees = db.relationship('SlidingScaleFee', backref='slidingscale', lazy='dynamic')
+
+class SlidingScaleFee(db.Model):
+  id = db.Column(db.Integer, primary_key=True)
+  sliding_scale_id = db.Column(db.Integer, db.ForeignKey("sliding_scale.id"))
+  name = db.Column(db.String(128))
+  price_absolute = db.Column(db.Integer)
+  price_percentage = db.Column(db.Integer)
 
 class User(db.Model):
   id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/consent.html
+++ b/app/templates/consent.html
@@ -5,7 +5,7 @@
     <div class="panel-heading"><h4>Almost there!</h4></div>
     <div class="panel-body">
       <p>In order to view this patient's information we need to make sure you have consent from them.</p>
-      <a class="btn btn-success" href="{{ url_for('patient_details', id=patient.id) }}" id="consent-button"><span class="glyphicon glyphicon-ok-circle"></span> CONSENT GIVEN</a>
+      <a class="btn btn-success" href="{{ url_for('consent_given', patient_id=patient.id) }}" id="consent-button"><span class="glyphicon glyphicon-ok-circle"></span> CONSENT GIVEN</a>
     </div>
   </div>
 

--- a/app/templates/new_prescreening.html
+++ b/app/templates/new_prescreening.html
@@ -5,33 +5,14 @@
 
     <form method="post">
     
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="resource_centers" name="services" checked="true">
-          Resource centers
-        </label>
-      </div>
-
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="cross_over" name="services" checked="true">
-          Cross Over
-        </label>
-      </div>
-
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="daily_planet" name="services" checked="true">
-          Daily Planet
-        </label>
-      </div>
-
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" class="text" value="access_now" name="services" checked="true">
-          Access Now
-        </label>
-      </div>
+      {% for service in services %}
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" class="text" value="{{service.id}}" name="services" checked="true">
+            {{service.name}}
+          </label>
+        </div>
+      {% endfor %}
 
       <button class="btn btn-primary"  type="submit">Check eligibility</button>       
     </form>

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
     <p>Your input:</p>
-    <p>${{household_income}} annual income for {{household_size}} household members = {{fpl | int}}% of the Federal Poverty Level</p>
-    <p>Has insurance: {{has_health_insurance}}</p>
-    <p>Eligible for Medicaid: {{is_eligible_for_medicaid}}</p>
+    <ul>
+        <li>Annual household income: ${{household_income}}</li>
+        <li>Household size: {{household_size}}</li>
+        <li>Has insurance: {{has_health_insurance}}</li>
+        <li>Eligible for Medicaid: {{is_eligible_for_medicaid}}</li>
+    </ul>
+    <h4>Federal Poverty Level percentage: {{fpl | int}}%</h4>
     {% for service in services %}
         <div class="service-pre-screen-result">
             <div 

--- a/app/templates/prescreening_results.html
+++ b/app/templates/prescreening_results.html
@@ -1,31 +1,81 @@
 {% extends "base.html" %}
 {% block content %}
-	{% for service in services %}
+    <p>Your input:</p>
+    <p>${{household_income}} annual income for {{household_size}} household members = {{fpl | int}}% of the Federal Poverty Level</p>
+    <p>Has insurance: {{has_health_insurance}}</p>
+    <p>Eligible for Medicaid: {{is_eligible_for_medicaid}}</p>
+    {% for service in services %}
         <div class="service-pre-screen-result">
-    		{% if service.eligible %}
-                <p class="alert alert-success">
-                    <span class="glyphicon glyphicon-ok push-right"></span>
-                    Good news!
-                </p>
-     			<h3>You are likely eligible for {{ service.name }}.</h3>
-                {% if service.general_fees %}
-                    {% for fee in service.general_fees %}
-                        <p>{{fee[0]}}: ${{fee[1]}}</p>
-                    {% endfor %}
+            <div 
+                {% if service.eligible %}
+                    class="alert alert-success"
+                {% else %}
+                    class="alert alert-danger"
                 {% endif %}
-                {% if service.name == 'Access Now' %}
-                    Access Now's services are free.
+            >
+                {% if service.eligible %}
+                    <h4>You are likely eligible for {{ service.name }}.</h4>
+                {% else %}
+                    <h4>You are likely not eligible for {{ service.name }}.</h4>
                 {% endif %}
-     		{% else %}
-     			<h3>You are likely not eligible for {{ service.name }}.</h3>
-        	{% endif %}
-            {% if service.sliding_scale %}
-                <h5>You're likely to fall in the {{service.sliding_scale}} section of the sliding scale.</h5>
+                {% if service.fpl_cutoff %}
+                    <div>
+                        {% if service.fpl_eligible %}
+                            <span class="glyphicon glyphicon-ok push-right"></span>
+                        {% else %}
+                            <span class="glyphicon glyphicon-remove push-right"></span>
+                        {% endif %}
+                        Income below {{service.fpl_cutoff}}% of the Federal Poverty Level
+                    </div>
+                {% endif %}
+                {% if service.uninsured_only_yn == 'Y' %}
+                    <div>
+                        {% if has_health_insurance == 'no' %}
+                            <span class="glyphicon glyphicon-ok push-right"></span>
+                        {% else %}
+                            <span class="glyphicon glyphicon-remove push-right"></span>
+                        {% endif %}
+                        Uninsured
+                    </div>
+                {% endif %}
+                {% if service.medicaid_ineligible_only_yn == 'Y' %}
+                    <div>
+                        {% if is_eligible_for_medicaid == 'no' %}
+                            <span class="glyphicon glyphicon-ok push-right"></span>
+                        {% else %}
+                            <span class="glyphicon glyphicon-remove push-right"></span>
+                        {% endif %}
+                        Not eligible for Medicaid
+                    </div>
+                {% endif %}
+            </div>
+
+            {% if service.eligible and service.sliding_scale %}
+                {% if service.sliding_scale != 'All' %}
+                    <p>You're likely to fall in the <strong>{{service.sliding_scale}}</strong> section of the sliding scale because your income is <strong>{{service.sliding_scale_range}}</strong> of the Federal Poverty Level.</p>
+                {% else %}
+                    <p>Service fees:</p>
+                {% endif %}
+
                 {% if service.sliding_scale != 'Full fee' %}
-                    {% for fee in service.sliding_scale_fees %}
-                        <p>{{fee[0]}}: ${{fee[1]}}</p>
-                    {% endfor %}
+                    <ul>
+                        {% for fee in service.sliding_scale_fees %}
+                            {% if fee.price_absolute %}
+                                <li>{{fee.name}}: ${{fee.price_absolute}}</li>
+                            {% else %}
+                                <li>{{fee.name}}: {{fee.price_percentage}}% of full price</li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
                 {% endif %}
+            {% endif %}
+            {% if service.eligible and service.general_fees %}
+                {% for fee in service.general_fees %}
+                    <p>{{fee[0]}}: ${{fee[1]}}</p>
+                {% endfor %}
+            {% endif %}
+            {% if service.eligible and service.name == 'Access Now' %}
+                Access Now provides service at no cost to the patient.
             {% endif %}
         </div>
     {% endfor %}

--- a/app/templates/search_new.html
+++ b/app/templates/search_new.html
@@ -14,8 +14,8 @@
           <p class="patient-dob">DOB: {{patient.dob}}</p>
           <p class="patient-lastedit">
             Associated with
-            {% for service in patient.patient_service_permissions %}
-              <a href="#">{{service.name}}</a>, 
+            {% for service in patient.services %}
+              <a href="#">{{service.name}}</a>{% if not loop.last %}, {% endif %} 
             {% endfor %}
           </p>
         </li>

--- a/app/templates/search_new.html
+++ b/app/templates/search_new.html
@@ -8,33 +8,19 @@
     <div id="patient-search">
       <div class="form-group"><input type="text" class="search form-control" placeholder="Search by name or date of birth." /></div>
 
-      {% macro patient(name) %}
+      {% for patient in patients %}
         <li class="patient-list-item col-sm-6">
-          <h3 class="patient-name">{{ name }} <a class="btn btn-default" href="{{ url_for('consent') }}">Add New Patient</a></h3>
-          <p class="patient-dob">DOB: xx/xx/xxxx</p>
-          <p class="patient-lastedit">Associated with <a href="#">Richmond Resource Centers</a>, <a href="">Daily Planet</a></p>
+          <h3 class="patient-name">{{ patient.first_name }} <a class="btn btn-default" href="{{ url_for('consent', patient_id=patient.id) }}">Add New Patient</a></h3>
+          <p class="patient-dob">DOB: {{patient.dob}}</p>
+          <p class="patient-lastedit">
+            Associated with
+            {% for service in patient.patient_service_permissions %}
+              <a href="#">{{service.name}}</a>, 
+            {% endfor %}
+          </p>
         </li>
-      {%- endmacro %}
+      {% endfor %}
 
-
-      <ul class="list">
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Shar Pie') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-        {{ patient('Patient Name') }}
-      </ul>
     <!-- /search -->
   </body>
 {% endblock %}    

--- a/app/views.py
+++ b/app/views.py
@@ -1,7 +1,7 @@
 import time, os, base64, hmac, urllib
 from flask import render_template, request,flash, redirect, url_for, g, send_from_directory, session, current_app
 from app import app, db, bcrypt
-from app.models import Patient, PhoneNumber, Address, EmergencyContact, Insurance, HouseholdMember, IncomeSource, Employer, DocumentImage, Service, User
+from app.models import Patient, PhoneNumber, Address, EmergencyContact, Insurance, HouseholdMember, IncomeSource, Employer, DocumentImage, Service, User, PatientServicePermission
 import datetime
 from flask.ext.login import login_user, logout_user, current_user, login_required
 from app import login_manager
@@ -89,6 +89,12 @@ def patient_details(id):
     db.session.commit()
     return redirect(url_for('patient_details', id=patient.id))
   else:
+    # If the user's service doesn't have permission to see this patient yet,
+    # redirect to consent page
+    if (current_user.service_id not in 
+      [permission.service_id for permission in patient.patient_service_permissions]):
+      return redirect(url_for('consent', patient_id = patient.id))
+
     patient.total_annual_income = sum(
       source.annual_amount for source in patient.income_sources
     )
@@ -99,6 +105,14 @@ def patient_details(id):
     return render_template('patient_details.html', patient=patient)
 
 def many_to_one_patient_updates(patient, form, files):
+  # If it's a new patient, they should initially be visible only to the service
+  # that created the entry
+  if patient.patient_service_permissions.count() == 0:
+    service_permission = PatientServicePermission(
+      service_id = current_user.service_id
+    )
+    patient.patient_service_permissions.append(service_permission)
+
   # Phone numbers
   phone_number_rows = [
     {'id': id, 'phone_number': phone_number, 'description': description, 'primary_yn': primary_yn}
@@ -474,6 +488,7 @@ def save_prescreening_updates():
 @login_required
 def search_new():
   patients = Patient.query.all()
+  patients = Patient.query.filter(~Patient.patient_service_permissions.any(PatientServicePermission.service_id == current_user.service_id))
   return render_template('search_new.html', patients=patients)
 
 # PRINT PATIENT DETAILS
@@ -494,14 +509,22 @@ def patient_print(patient_id):
 # to check if the user has permission to view the patient. When that
 # functionality is added we should delete the patient_details_new.html
 # template
-@app.route('/consent/')
+@app.route('/consent/<patient_id>')
 @login_required
-def consent():
-  # this is temporary!
-  patients = Patient.query.all()
-  first = patients[0]
-  print first.id
-  return render_template('consent.html', patient=first)
+def consent(patient_id):
+  patient = Patient.query.get(patient_id)
+  return render_template('consent.html', patient=patient)
+
+@app.route('/consent_given/<patient_id>')
+@login_required
+def consent_given(patient_id):
+  service_permission = PatientServicePermission(
+    patient_id = patient_id,
+    service_id = current_user.service_id
+  )
+  db.session.add(service_permission)
+  db.session.commit()
+  return redirect(url_for('patient_details', id = patient_id))
 
 # TEMPLATE PROTOTYPING
 # This is a dev-only route for prototyping fragments of other templates without touching
@@ -529,5 +552,6 @@ def patient_share(patient_id):
 @login_required
 def index():
   session.clear()
-  patients = Patient.query.all()
+  #patients = Patient.query.all()
+  patients = Patient.query.filter(Patient.patient_service_permissions.any(PatientServicePermission.service_id == current_user.service_id))
   return render_template('index.html', patients=patients)


### PR DESCRIPTION
- Adds PatientServicePermission model to hold many-to-many relationship between patients and services that have access to their information.
- Users can be associated with a single Service (this was true before, but it didn't do anything). We don't have an interface to add/edit users yet, so just updated user.service_id in the database manually for testing.
- When you add a new patient, the entry is automatically associated with the service your user account is associated with. The patient will appear on the "browse patients" page for any users associated with that service.
- Patients that are not associated with the current user's service appear on the "search new patients" page. The page shows each patient's existing service permissions.
  -When you click through the consent form for those patients, it will add a permission for the service you're associated with. Afterwards, the patient will appear on the "browse patients" page.
- If you manually go to the URL for a patient your service doesn't have access to, you'll be redirected to the consent page.
- All this closes #147. 
