### PR TITLE
wrapping tables with .table-wrapper for quick mobile fix, #62

### DIFF
--- a/app/templates/includes/patient_emergency_contact.html
+++ b/app/templates/includes/patient_emergency_contact.html
@@ -1,62 +1,64 @@
-<table class="table table-condensed emergency_contacts" id="emergency_contact_table">
+<div class="table-wrapper">
+  <table class="table table-condensed emergency_contacts" id="emergency_contact_table">
 
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Phone Number</th>
-      <th>Relationship</th>
-      <th>Edit</th>
-      <th>Delete</th>
-    </tr>
-  </thead>
-
-  {% if patient.emergency_contacts %}
-    {% for contact in patient.emergency_contacts %}
-      <tr class="emergency_contact">
-        <input class="hidden" value="{{contact.id}}" name="emergency_contact_id"/>
-        <td>
-          <div class="read-only">{{contact.name}}</div>
-          <input type="text" class="form-control hidden-input" name="emergency_contact_name" value="{{contact.name}}"/>
-        </td>
-        <td>
-          <div class="read-only">{{contact.phone_number}}</div>
-          <input type="tel" class="form-control hidden-input" name="emergency_contact_phone_number" value="{{contact.phone_number}}"/>
-        </td>
-        <td>
-          <div class="read-only">{{contact.relationship}}</div>
-          <input class="form-control hidden-input" type="text" name="emergency_contact_relationship" value="{{contact.relationship}}"/>
-        </td>
-        <td class="emergency_contact_edit">
-          <span
-            class="glyphicon glyphicon-pencil"
-            aria-hidden="true"
-            onclick="showHiddenFields()"
-          ></span>
-        </td>
-        <td class="emergency_contact_delete">
-          <span
-            class="glyphicon glyphicon-remove"
-            aria-hidden="true"
-            onclick="hideRow()"
-          ></span>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Phone Number</th>
+        <th>Relationship</th>
+        <th>Edit</th>
+        <th>Delete</th>
       </tr>
-    {% endfor %}
-  {% endif %}
+    </thead>
 
-  <tr class="emergency_contact" id="emergency_contact_input">
-    <td>
-      <input type="text" class="form-control" name="emergency_contact_name"/>
-    </td>
-    <td>
-      <input type="tel" class="form-control" name="emergency_contact_phone_number"/>
-    </td>
-    <td>
-      <input class="form-control" type="text" name="emergency_contact_relationship"/>
-    </td>
-    <td></td>
-  </tr>
+    {% if patient.emergency_contacts %}
+      {% for contact in patient.emergency_contacts %}
+        <tr class="emergency_contact">
+          <input class="hidden" value="{{contact.id}}" name="emergency_contact_id"/>
+          <td>
+            <div class="read-only">{{contact.name}}</div>
+            <input type="text" class="form-control hidden-input" name="emergency_contact_name" value="{{contact.name}}"/>
+          </td>
+          <td>
+            <div class="read-only">{{contact.phone_number}}</div>
+            <input type="tel" class="form-control hidden-input" name="emergency_contact_phone_number" value="{{contact.phone_number}}"/>
+          </td>
+          <td>
+            <div class="read-only">{{contact.relationship}}</div>
+            <input class="form-control hidden-input" type="text" name="emergency_contact_relationship" value="{{contact.relationship}}"/>
+          </td>
+          <td class="emergency_contact_edit">
+            <span
+              class="glyphicon glyphicon-pencil"
+              aria-hidden="true"
+              onclick="showHiddenFields()"
+            ></span>
+          </td>
+          <td class="emergency_contact_delete">
+            <span
+              class="glyphicon glyphicon-remove"
+              aria-hidden="true"
+              onclick="hideRow()"
+            ></span>
+        </tr>
+      {% endfor %}
+    {% endif %}
 
-</table>
+    <tr class="emergency_contact" id="emergency_contact_input">
+      <td>
+        <input type="text" class="form-control" name="emergency_contact_name"/>
+      </td>
+      <td>
+        <input type="tel" class="form-control" name="emergency_contact_phone_number"/>
+      </td>
+      <td>
+        <input class="form-control" type="text" name="emergency_contact_relationship"/>
+      </td>
+      <td></td>
+    </tr>
+
+  </table>
+</div>
 
 <div class="form-group add_emergency_contact">
   <button

--- a/app/templates/includes/patient_household_size.html
+++ b/app/templates/includes/patient_household_size.html
@@ -1,87 +1,88 @@
+<div class="table-wrapper">
+  <table class="table table-condensed hh_members" id="household_member_table">
 
-<table class="table table-condensed hh_members" id="household_member_table">
-
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>Name</th>
-      <th>DOB</th>
-      <th>SSN</th>
-      <th>Relationship</th>
-      <th>Edit</th>
-      <th>Delete</th>
-    </tr>
-  </thead>
-
-  <tr class="hh_member patient">
-    <td class="hh_member_number">1</td>
-    <td class="hh_member_full_name">{{patient.full_name or patient.first_name or 'Patient'}}</td>
-    <td class="hh_member_dob">{{patient.dob or ''}}</td>
-    <td class="hh_member_ssn">{{patient.ssn or ''}}</td>
-    <td class="hh_member_relation">Self</td>
-    <td class="hh_member_edit">
-    </td>
-  </tr>
-
-  {% if patient.household_members %}
-    {% for member in patient.household_members %}
-      <tr class="hh_member">
-        <td class="hh_member_number">
-          <input class="hidden" value="{{member.id}}" name="household_member_id">
-          {{ loop.index + 1}}
-        </td>
-        <td class="hh_member_full_name">
-          <div class="read-only">{{member.full_name}}</div>
-          <input class="form-control hidden-input" type="text" name="household_member_full_name" value="{{member.full_name}}"/>
-        </td>
-        <td class="hh_member_dob">
-          <div class="read-only">{{member.dob}}</div>
-          <input class="form-control hidden-input" type="date" name="household_member_dob" value="{{member.dob}}"/>
-        </td>
-        <td class="hh_member_ssn">
-          <div class="read-only">{{member.ssn}}</div>
-          <input class="form-control hidden-input" type="text" name="household_member_ssn" value="{{member.ssn}}"/>
-        </td>
-        <td class="hh_member_relation">
-          <div class="read-only">{{member.relationship}}</div>
-          <input class="form-control hidden-input" type="text" name="household_member_relation" value="{{member.relationship}}"/>
-        </td>
-        <td class="hh_member_edit">
-          <span
-            class="glyphicon glyphicon-pencil"
-            aria-hidden="true"
-            onclick="showHiddenFields()"
-          ></span>
-        </td>
-        <td class="hh_member_edit">
-          <span
-            class="glyphicon glyphicon-remove"
-            aria-hidden="true"
-            onclick="hideRow()"
-          ></span>
-        </td>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>DOB</th>
+        <th>SSN</th>
+        <th>Relationship</th>
+        <th>Edit</th>
+        <th>Delete</th>
       </tr>
-    {% endfor %}
-  {% endif %}
+    </thead>
 
-  <tr class="hh_member" id="household_member_input">
-    <td class="hh_member_number"></td>
-    <td class="hh_member_full_name">
-      <input class="form-control" type="text" name="household_member_full_name"/>
-    </td>
-    <td class="hh_member_age">
-      <input class="form-control" type="date" name="household_member_dob"/>
-    </td>
-    <td class="hh_member_ssn">
-      <input class="form-control" type="text" name="household_member_ssn"/>
-    </td>
-    <td class="hh_member_relation">
-      <input class="form-control" type="text" name="household_member_relation"/>
-    </td>
-    <td class="hh_member_edit"></td>
-  </tr>
+    <tr class="hh_member patient">
+      <td class="hh_member_number">1</td>
+      <td class="hh_member_full_name">{{patient.full_name or patient.first_name or 'Patient'}}</td>
+      <td class="hh_member_dob">{{patient.dob or ''}}</td>
+      <td class="hh_member_ssn">{{patient.ssn or ''}}</td>
+      <td class="hh_member_relation">Self</td>
+      <td class="hh_member_edit">
+      </td>
+    </tr>
 
-</table>
+    {% if patient.household_members %}
+      {% for member in patient.household_members %}
+        <tr class="hh_member">
+          <td class="hh_member_number">
+            <input class="hidden" value="{{member.id}}" name="household_member_id">
+            {{ loop.index + 1}}
+          </td>
+          <td class="hh_member_full_name">
+            <div class="read-only">{{member.full_name}}</div>
+            <input class="form-control hidden-input" type="text" name="household_member_full_name" value="{{member.full_name}}"/>
+          </td>
+          <td class="hh_member_dob">
+            <div class="read-only">{{member.dob}}</div>
+            <input class="form-control hidden-input" type="date" name="household_member_dob" value="{{member.dob}}"/>
+          </td>
+          <td class="hh_member_ssn">
+            <div class="read-only">{{member.ssn}}</div>
+            <input class="form-control hidden-input" type="text" name="household_member_ssn" value="{{member.ssn}}"/>
+          </td>
+          <td class="hh_member_relation">
+            <div class="read-only">{{member.relationship}}</div>
+            <input class="form-control hidden-input" type="text" name="household_member_relation" value="{{member.relationship}}"/>
+          </td>
+          <td class="hh_member_edit">
+            <span
+              class="glyphicon glyphicon-pencil"
+              aria-hidden="true"
+              onclick="showHiddenFields()"
+            ></span>
+          </td>
+          <td class="hh_member_edit">
+            <span
+              class="glyphicon glyphicon-remove"
+              aria-hidden="true"
+              onclick="hideRow()"
+            ></span>
+          </td>
+        </tr>
+      {% endfor %}
+    {% endif %}
+
+    <tr class="hh_member" id="household_member_input">
+      <td class="hh_member_number"></td>
+      <td class="hh_member_full_name">
+        <input class="form-control" type="text" name="household_member_full_name"/>
+      </td>
+      <td class="hh_member_age">
+        <input class="form-control" type="date" name="household_member_dob"/>
+      </td>
+      <td class="hh_member_ssn">
+        <input class="form-control" type="text" name="household_member_ssn"/>
+      </td>
+      <td class="hh_member_relation">
+        <input class="form-control" type="text" name="household_member_relation"/>
+      </td>
+      <td class="hh_member_edit"></td>
+    </tr>
+
+  </table>
+</div>
 
 <div class="form-group add_hh_member">
   <button


### PR DESCRIPTION
**What's this?**

Adding `.table-wrapper` class around tables on `patient_details.html` in order to prevent breaking on mobile. I recognize this is not ideal, but rebuilding tables into divs will take a bit more time than we have for testing this week.
