### PR TITLE
update temp data in edit history

### DIFF
--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -42,14 +42,14 @@
           <tr>
             <td>April 01 11:20am, 2015</td>
             <td><a href="#">Tulip Hernandez</a></td>
-            <td><a href="#">Resource Centers</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
             <td>Shared patient with <a href="">Crossover</a></td>
           </tr>
 
           <tr>
             <td>April 01 11:15am, 2015</td>
             <td><a href="#">Tulip Hernandez</a></td>
-            <td><a href="#">Resource Centers</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
             <td>Updated phone number from <code>(123) 345-7890</code> to <code>(123) 765-4321</code></td>
           </tr>
 

--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -8,8 +8,6 @@
 
         {% include "includes/patient_nav.html" %}
 
-        <h2>Edit History for {{ patient.full_name or patient.first_name }}</h2>
-
         <table class="table">
           <thead>
             <tr>
@@ -22,43 +20,99 @@
 
           <tr>
             <td>May 15 10:23am, 2015</td>
-            <td><a href="#">Mr. Beep Boop</a></td>
-            <td><a href="#">Crossover</a></td>
-            <td>Added household member</td>
+            <td><a href="#">George Hoffman</a></td>
+            <td><a href="#">CrossOver</a></td>
+            <td>Added household member: <code>Alex Brown (son)</code></td>
+          </tr>
+
+          <tr>
+            <td>May 15 10:23am, 2015</td>
+            <td><a href="#">George Hoffman</a></td>
+            <td><a href="#">CrossOver</a></td>
+            <td>Updated address from <code>568 Main St. Richmond, VA</code> to <code>1100 Maple Lane, Richmond VA</code></td>
           </tr>
 
           <tr>
             <td>May 15 10:10am, 2015</td>
-            <td><a href="#">Mr. Beep Boop</a></td>
-            <td><a href="#">Crossover</a></td>
-            <td>Confirmed patient access.</td>
+            <td><a href="#">George Hoffman</a></td>
+            <td><a href="#">CrossOver</a></td>
+            <td>Accessed patient record</td>
           </tr>
 
           <tr>
             <td>April 01 11:20am, 2015</td>
-            <td><a href="#">Tulip</a></td>
+            <td><a href="#">Tulip Hernandez</a></td>
             <td><a href="#">Resource Centers</a></td>
             <td>Shared patient with <a href="">Crossover</a></td>
           </tr>
 
           <tr>
             <td>April 01 11:15am, 2015</td>
-            <td><a href="#">Tulip</a></td>
+            <td><a href="#">Tulip Hernandez</a></td>
             <td><a href="#">Resource Centers</a></td>
-            <td>Updated primary phone number from <code>(123) 345-7890</code> to <code>(123) 765-4321</code></td>
+            <td>Updated phone number from <code>(123) 345-7890</code> to <code>(123) 765-4321</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added gender: <code>Female</code></td>
           </tr>
 
           <tr>
             <td>October 22 13:11pm, 2014</td>
-            <td><a href="#">Tulip</a></td>
+            <td><a href="#">Tulip Hernandez</a></td>
             <td><a href="#">Resource Centers</a></td>
-            <td>Added document (September Paystubs)</td>
+            <td>Added document: <code>September Paystubs</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added income source: <code>SSI</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added emergency contact: <code>Julian Brown</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added phone number: <code>(123) 345-7890</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added address: <code>568 Main St. Richmond, VA</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added DOB: <code>02/17/1968</code></td>
+          </tr>
+
+          <tr>
+            <td>October 21 15:03pm, 2014</td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
+            <td>Added full name: <code>Sherri Brown</code></td>
           </tr>
 
           <tr>
             <td>October 21 15:01pm, 2014</td>
-            <td><a href="#">Tulip</a></td>
-            <td><a href="#">Resource Centers</a></td>
+            <td><a href="#">Tulip Hernandez</a></td>
+            <td><a href="#">RCHD Resource Centers</a></td>
             <td>Patient profile created</td>
           </tr>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-    <a href="{{ url_for('search_new') }}" class="btn btn-success right"><span class="glyphicon glyphicon-eye-open"></span> Search new patients</a>
+<!--     <a href="{{ url_for('search_new') }}" class="btn btn-success right"><span class="glyphicon glyphicon-eye-open"></span> Search new patients</a> -->
 
     <!-- <div class="panel panel-default">
       <div class="panel-body">

--- a/app/templates/patient_share.html
+++ b/app/templates/patient_share.html
@@ -8,7 +8,6 @@
 
         {% include "includes/patient_nav.html" %}
 
-        <h2>{{ patient.full_name or patient.first_name }}</h2>
         <p>Who would you like to share this information with?</p>
 
         <div class="col-sm-6 service">


### PR DESCRIPTION
- Made the fake edit history data a bit more realistic.
- Removed the patient name from the edit history and sharing pages because it now appears under the patient photo on the left side of the page.
- Removed the "search new patients" button on the landing page because we now have a link in the nav bar.
