### PR TITLE
add patient list filter logic

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -156,6 +156,8 @@ class Patient(BasicTable, db.Model):
   patient_service_permissions = db.relationship('PatientServicePermission', backref='patient', lazy='dynamic')
   services = db.relationship('Service', secondary='patient_service_permission')
 
+  referrals = db.relationship('PatientReferral', backref='patient', lazy='dynamic')
+
   def __init__(self, **fields):
     self.__dict__.update(fields)
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,66 +7,52 @@
 
     <div class="block_3 sidebar">      
       <button data-list="0" class="filter filter_statistic filter_active">
-        <span class="statistic_number">145</span>
-        <span class="statistic_text"><strong>Total patients</strong> at Richmond Resource Centers.</span>
+        <span class="statistic_number">{{ all_patients | length }}</span>
+        <span class="statistic_text"><strong>Total patients in network</strong></span>
       </button>
 
       <button data-list="1" class="filter filter_statistic">
-        <span class="statistic_number">8</span>
-        <span class="statistic_text">Patients have been updated <strong>today</strong>.</span>
+        <span class="statistic_number">{{ recently_updated.count() }}</span>
+        <span class="statistic_text">Patients updated at {{ current_user.service.name }} in last week </span>
       </button>
 
       <button data-list="2" class="filter filter_statistic">
-        <span class="statistic_number">13</span>
-        <span class="statistic_text"><strong>New patients</strong> in the last week.</span>
+        <span class="statistic_number">{{ open_referrals.count() }}</span>
+        <span class="statistic_text">Patients with open referrals to {{ current_user.service.name }}</span>
       </button>
 
       <button data-list="3" class="filter filter_statistic">
-        <span class="statistic_number">21</span>
-        <span class="statistic_text">Patients have visited <strong>other clinics</strong> in the past month.</span>
+        <span class="statistic_number">{{ your_referrals.count() }}</span>
+        <span class="statistic_text">Patients you've referred elsewhere</span>
       </button>
 
-      <button data-list="4" class="filter filter_statistic">
-        <span class="statistic_number">54</span>
-        <span class="statistic_text">Patients <strong>haven't been updated</strong> in over a year.</span>
-      </button>
     </div>
 
     <div class="block_9 block_padding">
-      <ul id="list-0" class="list list_table list_filter list_filter_active">
-        {% for patient in patients %}
-          
-          <!--
-          TODO: Add classes to .list_row based on filters to the left of list
-          -->
-
-          <li class="list_row">
-            <a href="{{ url_for('screener.patient_details', id=patient.id) }}">
-              <span class="list_row_item list_row_name ">{{ patient.full_name or patient.first_name }}</span>
-              <span class="list_row_item list_row_dob">DOB: {{ patient.dob }}</span>
-              <span class="list_row_item list_row_edits">{{ _("Last edited by") }}: ___ {{ _("at") }} Richmond Resource Center</span>
-            </a>
-          </li>
-
-          <!-- ORIGINAL LOOP
-          <li class="patient-list-item clearfix col-sm-6 {% if loop.index < 3 %}new{% endif %} {% if loop.index == 3 %}recent{% endif %}">
-            <h3 class="patient-name">{{ patient.full_name or patient.first_name }}</h3>
-            <p class="patient-dob">DOB: {{ patient.dob }}</p>
-            <div class="completion-wrapper">
-              <div class="completion high" style="width:{{ loop.index }}9%"></div>
-            </div>
-            <div class="completion-percentage">{{ loop.index }}9% {{ _("completion") }}</div>
-            <p class="patient-lastedit left">
-              {{ _("Last edited by") }}: <a href="#">____</a> {{ _("at") }} <a href="#">Richmond Resource Center</a>
-            </p>
-            <a class="btn btn-default btn-sm right" href="{{ url_for('screener.patient_details', id=patient.id) }}">
-              {{ _("Details") }} <span class="glyphicon glyphicon-chevron-right"></span>
-            </a>
-          </li> 
-          /END ORIGINAL LOOP -->
-        {% endfor %}
-      </ul>
+      {% for patient_list in [
+        all_patients,
+        recently_updated,
+        open_referrals,
+        your_referrals
+      ] %}
+        <ul id="list-{{ loop.index - 1}}" class="list list_table list_filter {% if loop.index == 1 %} list_filter_active {% endif %}">
+          {% for patient in patient_list %}
+            <li class="list_row">
+              <a href="{{ url_for('screener.patient_details', id=patient.id) }}">
+                <span class="list_row_item list_row_name ">{{ patient.full_name or patient.first_name }}</span>
+                <span class="list_row_item list_row_dob">DOB: {{ patient.dob.strftime('%m/%d/%Y') }}</span>
+                {% if patient.last_modified_by %}
+                  <span class="list_row_item list_row_edits">{{ _("Last edited by") }}: {{ patient.last_modified_by.full_name }} {{ _("at") }} {{ patient.last_modified_by.service.name }}</span>
+                {% elif patient.created_by %}
+                  <span class="list_row_item list_row_edits">{{ _("Last edited by") }}: {{ patient.created_by.full_name }} {{ _("at") }} {{ patient.created_by.service.name }}</span>
+                {% endif %}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>   
+      {% endfor %}
     </div>
+
   </div>
 {% endblock %}
 


### PR DESCRIPTION
- Adds logic to show different sets of patients when users click numbers on index page. Current filters:
  - All patients in network
  - Patients added or edited at current user's organization in the last week
  - Patients with referrals to the current user's organization that are in open statuses (no eligibility decision made yet).
  - Patients the current user has referred elsewhere.
- Adds logic for the labels under each patient to replace hard coded text (last edited by user and service).
