### PR TITLE
fix redirect to login page from index

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,7 +26,7 @@ def register_extensions(app):
     bcrypt.init_app(app)
     babel.init_app(app)
     login_manager.init_app(app)
-    login_manager.login_view = 'login'
+    login_manager.login_view = '/login'
 
 def register_context_processors(app):
     from app.context_processors import (


### PR DESCRIPTION
Going to the index page while logged out was throwing an error rather than redirecting to login. It now redirects as expected.
