### PR TITLE
Add conditional display settings for fields

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -252,6 +252,7 @@ class PatientForm(Form):
   )
 
   # How long have you lived in the greater Richmond area?
+  # .time_living_in_area is parent node
   years_living_in_area = fields.IntegerField( _("Years"), [Optional()])
   months_living_in_area = fields.IntegerField( _("Months"), [Optional()])
   city_or_county_of_residence = fields.TextField(
@@ -285,8 +286,10 @@ class PatientForm(Form):
   )
 
   # How long have you been unemployed?
+  # time_unemployed is the parent node
   years_unemployed = fields.IntegerField( _("Years"), [Optional()])
   months_unemployed = fields.IntegerField( _("Months"), [Optional()])
+  # spouse_time_unemployed is the parent node
   spouse_years_unemployed = fields.IntegerField( _("Years"), [Optional()])
   spouse_months_unemployed = fields.IntegerField( _("Months"), [Optional()])
   # employment_changes

--- a/app/template_constants.py
+++ b/app/template_constants.py
@@ -18,7 +18,7 @@ LANGUAGE_CHOICES = [
         ("EN",    _("English")),
         ("ES",    _("Spanish")),
         ("AR",    _("Arabic")),
-        ("other", _("Other"))]
+        ("OTH", _("Other"))]
 
 STATE_CHOICES =[ ("AL", "AL - Alabama"), ("AK", "AK - Alaska"),
             ("AZ", "AZ - Arizona"), ("AR", "AR - Arkansas"),
@@ -56,7 +56,7 @@ HOUSING_STATUS_CHOICES = [
         ("TRA",   _("Is in Transitional housing for the homeless")),
         ("EMR",   _("Emergency Shelter")),
         ("STR",   _("On the street (car, encampment, abandoned building)")),
-        ("other", _("Other"))]
+        ("OTH", _("Other"))]
 
 EMPLOYMENT_STATUS_CHOICES = [
         ("",    ""),
@@ -97,7 +97,7 @@ RACE_CHOICES = [
         ("AA",    _("Black or African-American")),
         ("NHPI",  _("Native Hawaiian/Pacific Islander")),
         ("W",     _("White")),
-        ("other", _("Other"))]
+        ("OTH", _("Other"))]
 
 ETHNICITY_CHOICES = [
         ("",    ""),

--- a/app/templates/form_field_macros.html
+++ b/app/templates/form_field_macros.html
@@ -1,5 +1,5 @@
 {% macro render_field(field, providers=[], class='') -%}
-<label class="form_field field_{{field.name}}
+<label class="form_field {{field.name}}
   {%- if class %} {{class}}{% endif %}
   {%- if providers|length > 0 %} q_unique {% endif -%}
   {%- for provider in providers %} q_{{provider}}{% endfor -%}
@@ -10,4 +10,29 @@
   {{ field(class="field_input", **kwargs) }}
   <span class="field_verification"></span>
 </label>
+{% endmacro %}
+
+{% macro render_multifield(multifield_slug, multifield_label, subfields, providers=[], class='', subclass='') -%}
+<div class="multifield {{multifield_slug}}
+  {%- if class %} {{class}}{% endif %}
+  {%- if providers|length > 0 %} q_unique {% endif -%}
+  {%- for provider in providers %} q_{{provider}}{% endfor -%}
+  ">
+  <label class="multifield_label">
+    {{ multifield_label }}
+  </label>
+
+  <div class="subfields">
+  {% for field in subfields %}
+    <label class="form_field {{field.name}}
+    {%- if subclass %} {{subclass}}{% endif -%}
+      ">
+      <span class="field_label">
+        {{ field.label.text }}
+      </span>
+      {{ field(class="field_input", **kwargs) }}
+    </label>
+  {% endfor %}
+  </div>
+</div>
 {% endmacro %}

--- a/app/templates/includes/patient_demographic_info.html
+++ b/app/templates/includes/patient_demographic_info.html
@@ -7,13 +7,13 @@
 
   <div class="form_row">
     {{ render_field(form.race, class="block_4 has_other") }}
-    {{ render_field(form.race_other, class="block_4 hidden") }}
+    {{ render_field(form.race_other, class="block_4") }}
     {{ render_field(form.ethnicity, class="block_4") }}
   </div>
 
   <div class="form_row">
     {{ render_field(form.languages, class="block_6 has_other", rows=5) }}
-    {{ render_field(form.languages_other, class="block_4 hidden") }}
+    {{ render_field(form.languages_other, class="block_4") }}
     {{ render_field(form.has_interpreter_yn, ['an'], class="block_6") }}
   </div>
 
@@ -33,7 +33,7 @@
 
   <div class="form_row">
   {{ render_field(form.housing_status, class="block_6 has_other") }}
-  {{ render_field(form.housing_status_other, class="block_6 hidden") }}
+  {{ render_field(form.housing_status_other, class="block_6") }}
   </div>
 
   {{ render_field(form.education_level, ['an']) }}

--- a/app/templates/includes/patient_demographic_info.html
+++ b/app/templates/includes/patient_demographic_info.html
@@ -1,4 +1,4 @@
-{% from "form_field_macros.html" import render_field %}
+{% from "form_field_macros.html" import render_field, render_multifield %}
 
   <div class="form_row">
     {{ render_field(form.gender, class="block_4") }}
@@ -20,13 +20,17 @@
   {{ render_field(form.marital_status) }}
   {{ render_field(form.veteran_yn) }}
 
-  <div class="form-group q_an">
-    <label>{{ _("How long have you lived in the Greater Richmond Area?") }} </label>
-    {{ form.years_living_in_area.label }}
-    {{ form.years_living_in_area(class="form-control") }}
-    {{ form.months_living_in_area.label }}
-    {{ form.months_living_in_area(class="form-control") }}
-  </div>
+
+  {{ render_multifield(
+    "time_living_in_area",
+    _("How long have you lived in the Greater Richmond Area?"),
+    [
+      form.years_living_in_area, 
+      form.months_living_in_area
+    ], 
+    ['an'],
+    subclass="block_4"
+  ) }}
 
   {{ render_field(form.city_or_county_of_residence, ['an']) }}
   {{ render_field(form.temp_visa_yn, ['an']) }}

--- a/app/templates/includes/patient_employment_info.html
+++ b/app/templates/includes/patient_employment_info.html
@@ -89,14 +89,20 @@
 
   {{ render_multifield(
     "time_unemployed", _("How long have you been unemployed?"),
-    [form.years_unemployed, form.months_unemployed],
+    [
+      form.years_unemployed, 
+      form.months_unemployed
+    ], 
     ['an'],
     subclass="block_4"
   ) }}
 
   {{ render_multifield(
     "spouse_time_unemployed", _("How long has your spouse been unemployed?"),
-    [form.spouse_years_unemployed, form.spouse_months_unemployed],
+    [
+      form.spouse_years_unemployed, 
+      form.spouse_months_unemployed
+    ], 
     ['an'],
     subclass="block_4"
   ) }}

--- a/app/templates/includes/patient_employment_info.html
+++ b/app/templates/includes/patient_employment_info.html
@@ -1,4 +1,4 @@
-{% from "form_field_macros.html" import render_field %}
+{% from "form_field_macros.html" import render_field, render_multifield %}
 
   {{ render_field(form.employment_status) }}
   {{ render_field(form.student_status) }}
@@ -86,21 +86,20 @@
 </div>
 
 
-<div class="form-group q_an">
-  <label>{{ _("How long have you been unemployed?") }}</label>
-  {{ form.years_unemployed.label }}
-  {{ form.years_unemployed(class="form-control") }}
-  {{ form.months_unemployed.label }}
-  {{ form.months_unemployed(class="form-control") }}
-</div>
 
-<div class="form-group q_an">
-  <label>{{ _("How long has your spouse been unemployed?") }}</label>
-  {{ form.spouse_years_unemployed.label }}
-  {{ form.spouse_years_unemployed(class="form-control") }}
-  {{ form.spouse_months_unemployed.label }}
-  {{ form.spouse_months_unemployed(class="form-control") }}
-</div>
+  {{ render_multifield(
+    "time_unemployed", _("How long have you been unemployed?"),
+    [form.years_unemployed, form.months_unemployed],
+    ['an'],
+    subclass="block_4"
+  ) }}
+
+  {{ render_multifield(
+    "spouse_time_unemployed", _("How long has your spouse been unemployed?"),
+    [form.spouse_years_unemployed, form.spouse_months_unemployed],
+    ['an'],
+    subclass="block_4"
+  ) }}
 
   {{ render_field(form.years_at_current_employer, ['an']) }}
   {{ render_field(form.spouse_years_at_current_employer, ['an']) }}

--- a/app/templates/includes/patient_insurance_info.html
+++ b/app/templates/includes/patient_insurance_info.html
@@ -2,11 +2,10 @@
 
 {{ render_field(form.last_healthcare) }}
 {{ render_field(form.insurance_status) }}
-{{ render_field(form.coverage_type) }}
 
-<div class="form-group {% if form.coverage_type.data != "Other" %} hidden {% endif %}">
-  {{ form.coverage_type_other.label }}
-  {{ form.coverage_type_other(class="form-control") }}
+<div class="form_row">
+{{ render_field(form.coverage_type) }}
+{{ render_field(form.coverage_type_other) }}
 </div>
 
 {{ render_field(form.has_prescription_coverage_yn, ['an']) }}

--- a/front/js/question_dependencies.js
+++ b/front/js/question_dependencies.js
@@ -60,8 +60,8 @@ var DEPENDENCY_PROCESSORS = {
 
 function registerConditionalDisplay(d){
   // parse the dependency and get elements
-  var target = $(".field_"+d.target+" [name='"+d.target+"']");
-  var child = $(".field_"+d.child);
+  var target = $("."+d.target+" [name='"+d.target+"']");
+  var child = $("."+d.child);
   var processor = DEPENDENCY_PROCESSORS[d.type];
   var comparator = d.comparator;
   // make a function to hide or show the child element

--- a/front/js/question_dependencies.js
+++ b/front/js/question_dependencies.js
@@ -1,10 +1,46 @@
+var EMPLOYED = [ "FT", "PT", "SEA" ];
+
 var DEPENDENCIES = [
   { target: "marital_status", child: "spouse_employment_status", 
     type: "equals", comparator: "MAR" },
+  { target: "spouse_employment_status", child: "spouse_years_at_current_employer ", 
+    type: "in", comparator: EMPLOYED },
   { target: "employment_status", child: "employers",
-    type: "in", comparator: [ "FT", "PT", "SEA" ] },
+    type: "in", comparator: EMPLOYED },
+  { target: "employment_status", child: "years_at_current_employer ",
+    type: "in", comparator: EMPLOYED },
+  { target: "spouse_employment_status", child: "spouse_years_at_current_employer",
+    type: "in", comparator: EMPLOYED },
+  { target: "employment_status", child: "time_unemployed",
+    type: "equals", comparator: "UNE" },
+  { target: "spouse_employment_status", child: "spouse_time_unemployed",
+    type: "equals", comparator: "UNE" },
   { target: "insurance_status", child: "coverage_type",
     type: "equals", comparator: "Y" },
+
+  { target: "veteran_yn", child: "applied_for_vets_benefits_yn",
+    type: "equals", comparator: "Y" },
+  { target: "eligible_for_vets_benefits_yn", child: "applied_for_vets_benefits_yn",
+    type: "equals", comparator: "Y" },
+
+  { target: "applied_for_medicaid_yn", child: "medicaid_date_effective",
+    type: "equals", comparator: "Y" },
+  { target: "applied_for_ssd_yn", child: "ssd_date_effective",
+    type: "equals", comparator: "Y" },
+  { target: "are_due_to_accident", child: "accident_work_related_yn",
+    type: "equals", comparator: "Y" },
+
+  { target: "race", child: "race_other",
+    type: "equals", comparator: "OTH" },
+  { target: "languages", child: "languages_other",
+    type: "contains", comparator: "OTH" },
+  { target: "housing_status", child: "housing_status_other",
+    type: "equals", comparator: "OTH" },
+  { target: "coverage_type", child: "coverage_type_other",
+    type: "equals", comparator: "OTH" },
+
+  { target: "languages", child: "has_interpreter_yn",
+    type: "does_not_contain", comparator: "EN" },
 ];
 
 var DEPENDENCY_PROCESSORS = {
@@ -14,12 +50,18 @@ var DEPENDENCY_PROCESSORS = {
   "in": function(answer, comparator){
     return $.inArray(answer, comparator) > -1;
   },
+  "contains": function(answer, comparator){
+    return $.inArray(comparator, answer) > -1;
+  },
+  "does_not_contain": function(answer, comparator){
+    return $.inArray(comparator, answer) == -1;
+  },
 };
 
 function registerConditionalDisplay(d){
   // parse the dependency and get elements
-  var target = $("."+d.target+" [name='"+d.target+"']");
-  var child = $("."+d.child);
+  var target = $(".field_"+d.target+" [name='"+d.target+"']");
+  var child = $(".field_"+d.child);
   var processor = DEPENDENCY_PROCESSORS[d.type];
   var comparator = d.comparator;
   // make a function to hide or show the child element


### PR DESCRIPTION
This adds conditional display settings for a number of fields (#143, #183), including `other` fields (#176).

This does not erase values. So if someone says they are unemployed and then adds an employer, both values will be entered. This does not do any validation.
