### PR TITLE
fix error when saving new patient with no phone numbers

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -175,7 +175,7 @@ class PatientForm(Form):
   )
   phone_numbers = fields.FieldList(fields.FormField(
     PhoneNumberForm
-  ), min_entries=1)
+  ))
   addresses = fields.FieldList(fields.FormField(
     AddressForm
   ))


### PR DESCRIPTION
The new patient view was showing a phone number row with null values, which caused an error on saving. This has been fixed.
