### PR TITLE
move delete button off of scrolling save bar

### DIFF
--- a/app/templates/includes/patient_profile.html
+++ b/app/templates/includes/patient_profile.html
@@ -48,6 +48,11 @@
       <p>{{ _('Eligible for Medicaid') }}</p>
       <h2>waka</h2>
     </div> -->
-  </div>    
+  </div>
+  <br>
+  <a class="button button_red button_inverse delete-patient button_small" href="{{ url_for('screener.delete', id=patient.id) }}">
+    <i class="fa fa-folder-o"></i>
+    {{ _("Archive Patient") }}
+  </a>
 
 </div>

--- a/app/templates/patient_details.html
+++ b/app/templates/patient_details.html
@@ -135,10 +135,6 @@
 
   <div class="patient_details_actions">
     <div class="container">
-      <a class="button button_red button_inverse delete-patient float_right" href="{{ url_for('screener.delete', id=patient.id) }}">
-        <i class="fa fa-trash"></i>
-        <!-- {{ _("Delete patient") }} -->
-      </a>
       <button type="submit" class="button button_green float_right" style="margin-right: 1em;">
         <i class="fa fa-check"></i>
         {% if patient %}


### PR DESCRIPTION
- sounds like testers were close to accidentally hitting the delete button when it was next to the save button (makes sense!). Moving the delete button to the left-hand sidebar and renaming to "archive" to discuss what this actually means.
