### PR TITLE
fix local option on fake data script

### DIFF
--- a/add_data/clear_db.py
+++ b/add_data/clear_db.py
@@ -55,12 +55,14 @@ def main(app=create_app(), options=[]):
     db.create_all()
     engine.dispose()
 
+    print "Deleted all existing data"
+
     # Audit triggers aren't in SQLAlchemy schema definition, so create_all
     # won't recreate them. Run the separate script to add them.
     if '-local' in options:
       os.system('psql -d {} -a -f app/audit_triggers.sql'.format(engine.url.database))
+      print "Added audit triggers"
 
-    print "Deleted all existing data"
 
 if __name__ == '__main__':
   sys.exit(main(create_app(), sys.argv[1:]))

--- a/add_data/clear_db.py
+++ b/add_data/clear_db.py
@@ -63,4 +63,4 @@ def main(app=create_app(), options=[]):
     print "Deleted all existing data"
 
 if __name__ == '__main__':
-  sys.exit(main())
+  sys.exit(main(create_app(), sys.argv[1:]))


### PR DESCRIPTION
The -local option on clear_db.py wasn't working, so audit triggers weren't getting added. This fixes it.
