### PR TITLE
User permissions

### DIFF
--- a/add_data/add_mock_data.py
+++ b/add_data/add_mock_data.py
@@ -30,6 +30,7 @@ from app.models import (
     db
 )
 import app.template_constants as constants
+import add_roles
 import add_service_data
 
 
@@ -187,9 +188,19 @@ def add_users(services):
             password=bcrypt.generate_password_hash('password'),
             service_id=service.id,
             full_name=fake.name(),
-            phone_number=formatted_phone_number()
+            phone_number=formatted_phone_number(),
+            role_name='Staff'
         )
         db.session.add(user)
+
+    patient_user = AppUser(
+        email='patient_user@test.com',
+        password=bcrypt.generate_password_hash('password'),
+        full_name=fake.name(),
+        phone_number=formatted_phone_number()
+    )
+    db.session.add(patient_user)
+
     db.session.commit()
     app_users = AppUser.query.all()
 
@@ -250,7 +261,9 @@ def main(options=[]):
         # Add services, with locations, screening criteria, and sliding scales
         services = add_service_data.main(app)
 
-        # Add several users, associated with different services
+        # Add several staff users, associated with different services,
+        # and a patient user
+        add_roles.main(app)
         services = Service.query.all()
         app_users = add_users(services)
 

--- a/add_data/add_roles.py
+++ b/add_data/add_roles.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import sys
+from app import create_app
+from app.models import Role
+
+
+def main(app=create_app()):
+    with app.app_context():
+        Role.insert_roles()
+
+    print 'Added roles'
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,10 @@
 import sys
 import logging
 from flask import Flask, render_template
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.login import LoginManager
-from flask.ext.bcrypt import Bcrypt
 from flask.ext.babel import Babel
+from flask.ext.bcrypt import Bcrypt
+from flask.ext.login import LoginManager
+from flask.ext.sqlalchemy import SQLAlchemy
 from flask_s3 import FlaskS3
 from config import ProdConfig
 
@@ -53,11 +53,13 @@ def register_context_processors(app):
     from app.context_processors import (
         inject_static_url,
         inject_example_data,
-        inject_template_constants
+        inject_template_constants,
+        inject_permissions
     )
     app.context_processor(inject_static_url)
     app.context_processor(inject_example_data)
     app.context_processor(inject_template_constants)
+    app.context_processor(inject_permissions)
 
 
 def register_errorhandler(app):

--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -25,3 +25,8 @@ def inject_example_data():
 def inject_template_constants():
     from app import template_constants
     return dict(CONSTANTS=template_constants)
+
+
+def inject_permissions():
+    from app.models import Permission
+    return dict(PERMISSION=Permission)

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from flask import abort
+from flask.ext.login import current_user
+from app.models import Permission
+
+
+def permission_required(permission):
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if not current_user.can(permission):
+                abort(403)
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+
+def view_all_patients_required(f):
+    return permission_required(Permission.VIEW_ALL_PATIENTS)(f)
+
+
+def view_admin_pages_required(f):
+    return permission_required(Permission.VIEW_ADMIN_PAGES)(f)

--- a/app/templates/includes/nav.html
+++ b/app/templates/includes/nav.html
@@ -3,8 +3,10 @@
   <div class="nav_menu">
     <ul class="nav_menu_list">
       {% if g.user.is_authenticated() %}
-      <li class="menu_list_item {% if request.path == url_for('screener.new_prescreening') %}menu_list_item_current{% endif %}"><a href="{{ url_for('screener.new_prescreening') }}"><i class="fa fa-pencil"></i> {{ _("Pre-Screener") }}</a></li>
-      <li class="menu_list_item {% if request.path == url_for('screener.index') %}menu_list_item_current{% endif %}"><a href="{{ url_for('screener.index') }}"><i class="fa fa-search"></i> {{ _("Search Patients") }}</a></li>
+        <li class="menu_list_item {% if request.path == url_for('screener.new_prescreening') %}menu_list_item_current{% endif %}"><a href="{{ url_for('screener.new_prescreening') }}"><i class="fa fa-pencil"></i> {{ _("Pre-Screener") }}</a></li>
+        {% if g.user.can(PERMISSION.VIEW_ALL_PATIENTS) %}
+          <li class="menu_list_item {% if request.path == url_for('screener.index') %}menu_list_item_current{% endif %}"><a href="{{ url_for('screener.index') }}"><i class="fa fa-search"></i> {{ _("Search Patients") }}</a></li>
+        {% endif %}
       {% endif %}
     </ul>
   </div>

--- a/app/utils.py
+++ b/app/utils.py
@@ -7,7 +7,7 @@ from sqlalchemy import and_
 from werkzeug import secure_filename
 from werkzeug.datastructures import MultiDict
 
-from flask import current_app, send_from_directory, session
+from flask import current_app, send_from_directory, session, abort
 from flask.ext.login import login_user, current_user
 
 from app import db, bcrypt
@@ -131,3 +131,12 @@ def get_unsaved_form(request, patient, page_name, form_class):
 
             return form
     return False
+
+
+def check_patient_permission(patient_id):
+    """If the current user is a patient account, check whether they're viewing
+    the patient linked to their own account. If not, abort.
+    """
+    if current_user.is_patient_user() and current_user.patient_id != int(patient_id):
+        abort(403)
+    return

--- a/tests/unit/screener/test_screener.py
+++ b/tests/unit/screener/test_screener.py
@@ -331,6 +331,7 @@ class TestScreener(BaseTestCase):
 
     def test_patient_print(self):
         """Test that the print patient page works as expected."""
+        self.login()
         patient = get_patient()
         response = self.client.get('/patient_print/{}'.format(patient.id))
         self.assert200(response)
@@ -338,6 +339,7 @@ class TestScreener(BaseTestCase):
 
     def test_patient_history(self):
         """Test that the edit history page works as expected."""
+        self.login()
         patient = get_patient()
         response = self.client.get('/patient_history/{}'.format(patient.id))
         self.assert200(response)
@@ -345,6 +347,7 @@ class TestScreener(BaseTestCase):
 
     def test_patient_share(self):
         """Test that the share patient page works as expected."""
+        self.login()
         patient = get_patient()
         response = self.client.get('/patient_share/{}'.format(patient.id))
         self.assert200(response)

--- a/tests/unit/screener/utils.py
+++ b/tests/unit/screener/utils.py
@@ -1,6 +1,8 @@
-from app.models import AppUser, Service, Patient
+from app.models import AppUser, Service, Patient, Role
 from app import bcrypt, db
 
+def insert_roles():
+    Role.insert_roles()
 
 def get_user():
     existing_user = AppUser.query.filter(
@@ -13,11 +15,13 @@ def get_user():
 
 
 def insert_user():
+    insert_roles()
     service = get_service()
     app_user = AppUser(
         email='richmond@codeforamerica.org',
         password=bcrypt.generate_password_hash('password'),
-        service=service
+        service=service,
+        role_name='Staff'
     )
     db.session.add(app_user)
     db.session.commit()


### PR DESCRIPTION
- Adds four user roles: Patient, Staff, Admin, and Superuser. New users have the Patient role by default.
- Patient users are directed to the new patient page upon first login. After saving the patient, they're always directed to that patient's profile when they login. Patient users shouldn't see the landing page, so the "Search patients" link in the nav bar isn't visible to them. If they try to access the landing page or another patient via the URL, they'll get a 403 error.
- Staff, Admin, and Superuser accounts behave the way all user accounts did up to this point. In theory, Admin users will be able to access admin pages for their organization, and Superusers will be able to access admin pages for all organizations. We don't have admin pages yet, so they're all effectively the same right now.
- Updates mock data scripts to add roles and add a patient user, and updates some tests to take roles into account.
