### PR TITLE
Style guide

### DIFF
--- a/app/templates/style-guide.html
+++ b/app/templates/style-guide.html
@@ -32,346 +32,40 @@
   <p><strong>RVA Screener Style Guide</strong></p>
   <p>Below are the style components used throughout the application. The <code>front/sass/</code> files are structured to containe specific UI components, using constant variables from <code>front/sass/variables.scss</code>.</p>
 
-  <section class="style-guide-section">
-    <span class="style-guide-header">Colors</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-  <style>
-    .style-guide-color-block {
-      padding: 1em;
-      height: 100px;
-      border: 1px solid white;
-    }
-  </style>
-  <div class="row">
-    <div class="color-black block_3 style-guide-color-block"><code style="color: white;">.color-black</code></div>
-    <div class="color-white block_3 style-guide-color-block"><code>.color-white</code></div>
-    <div class="color-lightgray block_3 style-guide-color-block"><code>.color-lightgray</code></div>
-    <div class="color-gray block_3 style-guide-color-block"><code>.color-gray</code></div>
-    <div class="color-darkgray block_3 style-guide-color-block"><code>.color-darkgray</code></div>
-    <div class="color-blue block_3 style-guide-color-block"><code>.color-blue</code></div>
-    <div class="color-red block_3 style-guide-color-block"><code>.color-red</code></div>
-    <div class="color-green block_3 style-guide-color-block"><code>.color-green</code></div>
-    <div class="color-fuscia block_3 style-guide-color-block"><code>.color-fuscia</code></div>
-    <div class="color-brightgreen block_3 style-guide-color-block"><code>.color-brightgreen</code></div>
-  </div>
+  {% include "style-guide/colors.html" %}
+  {% include "style-guide/typography.html" %}
+  {% include "style-guide/blocks.html" %}
+  {% include "style-guide/alerts.html" %}
+  {% include "style-guide/notifications.html" %}
+  {% include "style-guide/checkboxes.html" %}
+  {% include "style-guide/buttons.html" %}
+  {% include "style-guide/tooltips.html" %}
+  {% include "style-guide/forms.html" %}
+  {% include "style-guide/tabs.html" %}
+  {% include "style-guide/filters.html" %}
+  {% include "style-guide/lists.html" %}
+  {% include "style-guide/maps.html" %}
   
-  <section class="style-guide-section">
-    <span class="style-guide-header">Text, headings, links</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-  <h1>Header 1</h1>
-  <h2>Header 2</h2>
-  <h3>Header 3</h3>
-  <h4>Header 4</h4>
-  <h1><a href="">Header 1 with link</a></h1>
-  <h2><a href="">Header 2 with link</a></h2>
-  <h3><a href="">Header 3 with link</a></h3>
-  <h4><a href="">Header 4 with link</a></h4>
-  <p>Lorem ipsum dolor sit amet, <strong>strong text</strong> elit. Sed tincidunt semper diam non mattis. Nullam non facilisis ex, in sollicitudin turpis. Pellentesque in mattis ex, id porta dui. Suspendisse non accumsan risus. Duis consequat nunc lacinia arcu consequat, eu elementum purus congue. <a href="">Text with a link</a> vehicula blandit diam sit amet tristique. Duis hendrerit dui eros, a scelerisque lacus placerat ornare. Nam ultricies, nisi vitae commodo consectetur, ligula odio pellentesque justo, eu varius mauris ipsum lobortis erat. Nullam scelerisque imperdiet ipsum, et malesuada tellus convallis quis. Donec condimentum tempor urna id accumsan. Suspendisse tempor iaculis urna ut efficitur. Nulla auctor dolor in velit vulputate iaculis. Maecenas tincidunt erat quis rutrum eleifend.</p>
 
-  <section class="style-guide-section">
-    <span class="style-guide-header">Blocks</span>
-    <p class="style-guide-explanation">Blocks are the essential dividers used in the application. They can be used for major layouts or small components. They are floating elements, so make sure to wrap them within a <code>.row</code> element for a proper clearfix. All blocks are styled <code>box-sizing: border-box</code> so padding and margins are added inwards, not outwards.</p>
-  </section>
-  <style>
-    .style-guide-block {
-      background: #f6f6f6;
-      height: 200px;
-      border: 1px solid #fff;
-    }
-  </style>
-  <div class="row">
-    <div class="block_8 style-guide-block"><code>.block_8</code></div>
-    <div class="block_4 style-guide-block"><code>.block_4</code></div>
-  </div>
 
-  <div class="row">
-    <div class="block_6 style-guide-block block_padding"><code>.block_6 block_padding</code></div>
-    <div class="block_6 style-guide-block block_padding"><code>.block_6 block_padding</code></div>
-  </div>
+  
 
-  <div class="row">
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-    <div class="block_1 style-guide-block"><code>.block_1</code></div>
-  </div>
+  
 
-  <section class="style-guide-section">
-    <span class="style-guide-header">Alerts</span>
-    <p class="style-guide-explanation">Alerts are used for user feedback based on success or errors. They are <code>&lt;ul&gt;</code>'s with the <code>.alert_list</code> class and a modifying class for success and failure (see below). They are mostly injected via the jinja templates, which means there is no way to load them via javascript right now.</p>
-  </section>
+  
 
-  <ul class="alert_list alert_success">
-    <li>Success! <code>.alert_success</code></li>
-    <li>You can have multiple messages in one alert.</li>
-    <li>One more.</li>
-  </ul>
+  
 
-  <ul class="alert_list alert_error">
-    <li>Error! <code>.alert_error</code></li>
-  </ul>
+  
 
-  <pre class="style-guide-code">
-<span class="style-guide-code-comment">&lt;!-- success --&gt;</span>
-&lt;ul class="alert_list alert_success"&gt;
-  &lt;li&gt;Success!&lt;/li&gt;
-&lt;/ul&gt;
+  
+  
 
-<span class="style-guide-code-comment">&lt;!-- error --&gt;</span>
-&lt;ul class="alert_list alert_error"&gt;
-  &lt;li&gt;Error!&lt;/li&gt;
-&lt;/ul&gt;</pre>
+  
 
-  <section class="style-guide-section">
-    <span class="style-guide-header">Notifications</span>
-    <p class="style-guide-explanation"></p>
-  </section>
+  
 
-  <section class="style-guide-section">
-    <span class="style-guide-header">Boxes</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Buttons</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Maps</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Tooltips</span>
-    <p class="style-guide-explanation">Tooltips are used to add extra information to an element in the page. This information should not be priority to the user in order to interact with the app properly!</p>
-  </section>
-  <style>
-    .style-guide-tooltip {
-      max-width: 400px;
-      height: 100px;
-      background: #f6f6f6;
-      display: block;
-      margin: auto;
-      padding: 10px;
-    }
-  </style>
-
-  <div class="tooltip tooltip_right style-guide-tooltip" value="Here's a tip - drink water."><code>.tooltip.tooltip_right</code></div><br>
-
-  <div class="tooltip tooltip_left style-guide-tooltip" value="How is your day going?"><code>.tooltip.tooltip_left</code></div><br>
-
-  <div class="tooltip tooltip_top style-guide-tooltip" value="Life's greatest treasure is hidden."><code>.tooltip.tooltip_top</code></div><br>
-
-  <div class="tooltip tooltip_bottom style-guide-tooltip" value="Arrrrr. Give me your gold dabloons!"><code>.tooltip.tooltip_bottom</code></div><br>
-
-  <pre class="style-guide-code">
-<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_right --&gt;</span>
-&lt;div class="tooltip tooltip_right" value="Here's a tip - drink water."&gt;&lt;/div&gt;
-
-<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_left --&gt;</span>
-&lt;div class="tooltip tooltip_left" value="How is your day going?"&gt;&lt;/div&gt;
-
-<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_top --&gt;</span>
-&lt;div class="tooltip tooltip_top" value="Life's greatest treasure is hidden."&gt;&lt;/div&gt;
-
-<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_bottom --&gt;</span>
-&lt;div class="tooltip tooltip_bottom" value="Arrrrr. Give me your gold dabloons!"&gt;&lt;/div&gt;</pre>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Forms</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Tabs</span>
-    <p class="style-guide-explanation">Tabs are used to shuffle between related views, such as a patient's information, sharing that patient, etc. The mobile version of tabs turns into a <code>select</code> field that, when selected, brings the user to the new view. These are typically generated in jinja templates.</p>
-  </section>
-
-  <nav class="nav_tabs">
-    <div class="tabs">
-      <a class="tab tab_active" href="/patient_details/2"><i class="fa fa-home"></i> Home</a>
-      <a class="tab" href=""><i class="fa fa-share"></i> Share</a>
-      <a class="tab" href=""><i class="fa fa-pencil"></i> Edit</a>
-      <a class="tab" href=""><i class="fa fa-download"></i> Export</a>
-    </div>
-
-    <select class="tabs_dropdown" onchange="location = this.options[this.selectedIndex].value;">
-      <option value="">Select an action...</option>
-      <option value="">Home</option>
-      <option value="">Share</option>
-      <option value="">Edit</option>
-      <option value="">Export</option>
-    </select>
-  </nav>
-
-  <pre class="style-guide-code">
-&lt;nav class="nav_tabs"&gt;
-  &lt;div class="tabs"&gt;
-    &lt;a class="tab tab_active" href="/patient_details/2"&gt;&lt;i class="fa fa-home"&gt;&lt;/i&gt; Home&lt;/a&gt;
-    &lt;a class="tab" href=""&gt;&lt;i class="fa fa-share"&gt;&lt;/i&gt; Share&lt;/a&gt;
-    &lt;a class="tab" href=""&gt;&lt;i class="fa fa-pencil"&gt;&lt;/i&gt; Edit&lt;/a&gt;
-    &lt;a class="tab" href=""&gt;&lt;i class="fa fa-download"&gt;&lt;/i&gt; Export&lt;/a&gt;
-  &lt;/div&gt;
-
-  &lt;select class="tabs_dropdown" onchange="location = this.options[this.selectedIndex].value;"&gt;
-    &lt;option value=""&gt;Select an action...&lt;/option&gt;
-    &lt;option value=""&gt;Home&lt;/option&gt;
-    &lt;option value=""&gt;Share&lt;/option&gt;
-    &lt;option value=""&gt;Edit&lt;/option&gt;
-    &lt;option value=""&gt;Export&lt;/option&gt;
-  &lt;/select&gt;
-&lt;/nav&gt;</pre>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Filters / Switchers</span>
-    <p class="style-guide-explanation">Used for navigating between different lists or in-page pieces of information without switching views. <strong>This currently has no proper mobile version!</strong></p>
-  </section>
-  <style>
-    .style-guide-filter-list ul li {
-      padding: 10px 5px;
-    }
-  </style>
-
-  <div class="row style-guide-filter-list">
-    <div class="block_3">      
-      <button data-list="0" class="filter filter_statistic filter_active">
-        <span class="statistic_number">5</span>
-        <span class="statistic_text"><strong>Tum laborum</strong></span>
-      </button>
-
-      <button data-list="1" class="filter filter_statistic">
-        <span class="statistic_number">4</span>
-        <span class="statistic_text">accusamus quos possimus</span>
-      </button>
-    </div>
-
-    <div class="block_9 block_padding">
-      <ul id="list-0" class="list list_table list_filter list_filter_active">
-        <li class="list_row">Lorem ipsum dolor sit amet</li>
-        <li class="list_row">consectetur adipisicing elit</li>
-        <li class="list_row">Ea amet iusto ab nisi numquam</li>
-        <li class="list_row">Tum laborum fugit labore dolorem</li>
-        <li class="list_row">quam nemo accusamus quos possimus</li>
-      </ul>
-
-      <ul id="list-1" class="list list_table list_filter">
-        <li class="list_row">Ea amet iusto ab nisi numquam</li>
-        <li class="list_row">Tum laborum fugit labore dolorem</li>
-        <li class="list_row">Lorem ipsum dolor sit amet</li>
-        <li class="list_row">quam nemo accusamus quos possimus</li>
-      </ul>
-    </div>
-  </div>
-
-  <pre class="style-guide-code">
-&lt;div class="row"&gt;
-  &lt;div class="block_3"&gt;      
-    &lt;button data-list="0" class="filter filter_statistic filter_active"&gt;
-      &lt;span class="statistic_number"&gt;5&lt;/span&gt;
-      &lt;span class="statistic_text"&gt;&lt;strong&gt;Tum laborum&lt;/strong&gt;&lt;/span&gt;
-    &lt;/button&gt;
-
-    &lt;button data-list="1" class="filter filter_statistic"&gt;
-      &lt;span class="statistic_number"&gt;4&lt;/span&gt;
-      &lt;span class="statistic_text"&gt;accusamus quos possimus&lt;/span&gt;
-    &lt;/button&gt;
-  &lt;/div&gt;
-
-  &lt;div class="block_9 block_padding"&gt;
-    &lt;ul id="list-0" class="list list_table list_filter list_filter_active"&gt;
-      &lt;li class="list_row"&gt;Lorem ipsum dolor sit amet&lt;/li&gt;
-      &lt;li class="list_row"&gt;consectetur adipisicing elit&lt;/li&gt;
-      &lt;li class="list_row"&gt;Ea amet iusto ab nisi numquam&lt;/li&gt;
-      &lt;li class="list_row"&gt;Tum laborum fugit labore dolorem&lt;/li&gt;
-      &lt;li class="list_row"&gt;quam nemo accusamus quos possimus&lt;/li&gt;
-    &lt;/ul&gt;
-
-    &lt;ul id="list-1" class="list list_table list_filter"&gt;
-      &lt;li class="list_row"&gt;Ea amet iusto ab nisi numquam&lt;/li&gt;
-      &lt;li class="list_row"&gt;Tum laborum fugit labore dolorem&lt;/li&gt;
-      &lt;li class="list_row"&gt;Lorem ipsum dolor sit amet&lt;/li&gt;
-      &lt;li class="list_row"&gt;quam nemo accusamus quos possimus&lt;/li&gt;
-    &lt;/ul&gt;
-  &lt;/div&gt;
-&lt;/div&gt;</pre>
-
-  <section class="style-guide-section">
-    <span class="style-guide-header">Lists</span>
-    <p class="style-guide-explanation"></p>
-  </section>
-
-  <p><strong>Basic list</strong></p>
-  <ul class="list list_table">
-    <li class="list_row">
-      Something in a <code>.list_row</code>
-    </li>
-    <li class="list_row">
-      Something in a <code>.list_row</code>
-    </li>
-    <li class="list_row">
-      Something in a <code>.list_row</code>
-    </li>
-    <li class="list_row">
-      Something in a <code>.list_row</code>
-    </li>
-    <li class="list_row">
-      Something in a <code>.list_row</code>
-    </li>  
-  </ul>
-  <pre class="style-guide-code">
-&lt;ul class="list list_table"&gt;
-  &lt;li class="list_row"&gt;
-    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
-  &lt;/li&gt;
-  &lt;li class="list_row"&gt;
-    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
-  &lt;/li&gt;
-  &lt;li class="list_row"&gt;
-    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
-  &lt;/li&gt;
-  &lt;li class="list_row"&gt;
-    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
-  &lt;/li&gt;
-  &lt;li class="list_row"&gt;
-    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
-  &lt;/li&gt;  
-&lt;/ul&gt;
-  </pre>
-
-  <p><strong>List with blocks</strong></p>
-  <ul class="list list_table">
-    <li class="list_row">
-      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
-      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
-    </li>
-    <li class="list_row">
-      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
-      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
-    </li>
-    <li class="list_row">
-      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
-      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
-    </li>
-    <li class="list_row">
-      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
-      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
-    </li>
-    <li class="list_row">
-      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
-      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
-    </li>  
-  </ul>
+  
 
 
 

--- a/app/templates/style-guide.html
+++ b/app/templates/style-guide.html
@@ -45,30 +45,6 @@
   {% include "style-guide/filters.html" %}
   {% include "style-guide/lists.html" %}
   {% include "style-guide/maps.html" %}
-  
-
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-  
-
-  
-
-  
-
-  
-
-
-
 
 </div>
 

--- a/app/templates/style-guide.html
+++ b/app/templates/style-guide.html
@@ -1,0 +1,381 @@
+{% extends "base.html" %}
+{% block content %}
+
+<style>
+  .style-guide-section {
+    margin-top: 5em;
+    margin-bottom: 1em;
+    border-bottom: 1px solid #e5e5e5;
+  }
+  .style-guide-header {
+    display: block;
+    font-size: 2em;
+    color: #c0c0c0;
+  }
+  .style-guide-explanation {
+    font-size: 0.9em;
+    color: #999;
+    max-width: 700px;
+  }
+  .style-guide-code {
+    background: #f6f6f6;
+    padding: 10px;
+    border-left: 5px solid #333;
+    margin-top: 3em;
+  }
+  .style-guide-code-comment {
+    color: #999;
+  }
+</style>
+
+<div class="container">
+  <p><strong>RVA Screener Style Guide</strong></p>
+  <p>Below are the style components used throughout the application. The <code>front/sass/</code> files are structured to containe specific UI components, using constant variables from <code>front/sass/variables.scss</code>.</p>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Colors</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+  <style>
+    .style-guide-color-block {
+      padding: 1em;
+      height: 100px;
+      border: 1px solid white;
+    }
+  </style>
+  <div class="row">
+    <div class="color-black block_3 style-guide-color-block"><code style="color: white;">.color-black</code></div>
+    <div class="color-white block_3 style-guide-color-block"><code>.color-white</code></div>
+    <div class="color-lightgray block_3 style-guide-color-block"><code>.color-lightgray</code></div>
+    <div class="color-gray block_3 style-guide-color-block"><code>.color-gray</code></div>
+    <div class="color-darkgray block_3 style-guide-color-block"><code>.color-darkgray</code></div>
+    <div class="color-blue block_3 style-guide-color-block"><code>.color-blue</code></div>
+    <div class="color-red block_3 style-guide-color-block"><code>.color-red</code></div>
+    <div class="color-green block_3 style-guide-color-block"><code>.color-green</code></div>
+    <div class="color-fuscia block_3 style-guide-color-block"><code>.color-fuscia</code></div>
+    <div class="color-brightgreen block_3 style-guide-color-block"><code>.color-brightgreen</code></div>
+  </div>
+  
+  <section class="style-guide-section">
+    <span class="style-guide-header">Text, headings, links</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+  <h1>Header 1</h1>
+  <h2>Header 2</h2>
+  <h3>Header 3</h3>
+  <h4>Header 4</h4>
+  <h1><a href="">Header 1 with link</a></h1>
+  <h2><a href="">Header 2 with link</a></h2>
+  <h3><a href="">Header 3 with link</a></h3>
+  <h4><a href="">Header 4 with link</a></h4>
+  <p>Lorem ipsum dolor sit amet, <strong>strong text</strong> elit. Sed tincidunt semper diam non mattis. Nullam non facilisis ex, in sollicitudin turpis. Pellentesque in mattis ex, id porta dui. Suspendisse non accumsan risus. Duis consequat nunc lacinia arcu consequat, eu elementum purus congue. <a href="">Text with a link</a> vehicula blandit diam sit amet tristique. Duis hendrerit dui eros, a scelerisque lacus placerat ornare. Nam ultricies, nisi vitae commodo consectetur, ligula odio pellentesque justo, eu varius mauris ipsum lobortis erat. Nullam scelerisque imperdiet ipsum, et malesuada tellus convallis quis. Donec condimentum tempor urna id accumsan. Suspendisse tempor iaculis urna ut efficitur. Nulla auctor dolor in velit vulputate iaculis. Maecenas tincidunt erat quis rutrum eleifend.</p>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Blocks</span>
+    <p class="style-guide-explanation">Blocks are the essential dividers used in the application. They can be used for major layouts or small components. They are floating elements, so make sure to wrap them within a <code>.row</code> element for a proper clearfix. All blocks are styled <code>box-sizing: border-box</code> so padding and margins are added inwards, not outwards.</p>
+  </section>
+  <style>
+    .style-guide-block {
+      background: #f6f6f6;
+      height: 200px;
+      border: 1px solid #fff;
+    }
+  </style>
+  <div class="row">
+    <div class="block_8 style-guide-block"><code>.block_8</code></div>
+    <div class="block_4 style-guide-block"><code>.block_4</code></div>
+  </div>
+
+  <div class="row">
+    <div class="block_6 style-guide-block block_padding"><code>.block_6 block_padding</code></div>
+    <div class="block_6 style-guide-block block_padding"><code>.block_6 block_padding</code></div>
+  </div>
+
+  <div class="row">
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+    <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  </div>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Alerts</span>
+    <p class="style-guide-explanation">Alerts are used for user feedback based on success or errors. They are <code>&lt;ul&gt;</code>'s with the <code>.alert_list</code> class and a modifying class for success and failure (see below). They are mostly injected via the jinja templates, which means there is no way to load them via javascript right now.</p>
+  </section>
+
+  <ul class="alert_list alert_success">
+    <li>Success! <code>.alert_success</code></li>
+    <li>You can have multiple messages in one alert.</li>
+    <li>One more.</li>
+  </ul>
+
+  <ul class="alert_list alert_error">
+    <li>Error! <code>.alert_error</code></li>
+  </ul>
+
+  <pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;!-- success --&gt;</span>
+&lt;ul class="alert_list alert_success"&gt;
+  &lt;li&gt;Success!&lt;/li&gt;
+&lt;/ul&gt;
+
+<span class="style-guide-code-comment">&lt;!-- error --&gt;</span>
+&lt;ul class="alert_list alert_error"&gt;
+  &lt;li&gt;Error!&lt;/li&gt;
+&lt;/ul&gt;</pre>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Notifications</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Boxes</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Buttons</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Maps</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Tooltips</span>
+    <p class="style-guide-explanation">Tooltips are used to add extra information to an element in the page. This information should not be priority to the user in order to interact with the app properly!</p>
+  </section>
+  <style>
+    .style-guide-tooltip {
+      max-width: 400px;
+      height: 100px;
+      background: #f6f6f6;
+      display: block;
+      margin: auto;
+      padding: 10px;
+    }
+  </style>
+
+  <div class="tooltip tooltip_right style-guide-tooltip" value="Here's a tip - drink water."><code>.tooltip.tooltip_right</code></div><br>
+
+  <div class="tooltip tooltip_left style-guide-tooltip" value="How is your day going?"><code>.tooltip.tooltip_left</code></div><br>
+
+  <div class="tooltip tooltip_top style-guide-tooltip" value="Life's greatest treasure is hidden."><code>.tooltip.tooltip_top</code></div><br>
+
+  <div class="tooltip tooltip_bottom style-guide-tooltip" value="Arrrrr. Give me your gold dabloons!"><code>.tooltip.tooltip_bottom</code></div><br>
+
+  <pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_right --&gt;</span>
+&lt;div class="tooltip tooltip_right" value="Here's a tip - drink water."&gt;&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_left --&gt;</span>
+&lt;div class="tooltip tooltip_left" value="How is your day going?"&gt;&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_top --&gt;</span>
+&lt;div class="tooltip tooltip_top" value="Life's greatest treasure is hidden."&gt;&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_bottom --&gt;</span>
+&lt;div class="tooltip tooltip_bottom" value="Arrrrr. Give me your gold dabloons!"&gt;&lt;/div&gt;</pre>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Forms</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Tabs</span>
+    <p class="style-guide-explanation">Tabs are used to shuffle between related views, such as a patient's information, sharing that patient, etc. The mobile version of tabs turns into a <code>select</code> field that, when selected, brings the user to the new view. These are typically generated in jinja templates.</p>
+  </section>
+
+  <nav class="nav_tabs">
+    <div class="tabs">
+      <a class="tab tab_active" href="/patient_details/2"><i class="fa fa-home"></i> Home</a>
+      <a class="tab" href=""><i class="fa fa-share"></i> Share</a>
+      <a class="tab" href=""><i class="fa fa-pencil"></i> Edit</a>
+      <a class="tab" href=""><i class="fa fa-download"></i> Export</a>
+    </div>
+
+    <select class="tabs_dropdown" onchange="location = this.options[this.selectedIndex].value;">
+      <option value="">Select an action...</option>
+      <option value="">Home</option>
+      <option value="">Share</option>
+      <option value="">Edit</option>
+      <option value="">Export</option>
+    </select>
+  </nav>
+
+  <pre class="style-guide-code">
+&lt;nav class="nav_tabs"&gt;
+  &lt;div class="tabs"&gt;
+    &lt;a class="tab tab_active" href="/patient_details/2"&gt;&lt;i class="fa fa-home"&gt;&lt;/i&gt; Home&lt;/a&gt;
+    &lt;a class="tab" href=""&gt;&lt;i class="fa fa-share"&gt;&lt;/i&gt; Share&lt;/a&gt;
+    &lt;a class="tab" href=""&gt;&lt;i class="fa fa-pencil"&gt;&lt;/i&gt; Edit&lt;/a&gt;
+    &lt;a class="tab" href=""&gt;&lt;i class="fa fa-download"&gt;&lt;/i&gt; Export&lt;/a&gt;
+  &lt;/div&gt;
+
+  &lt;select class="tabs_dropdown" onchange="location = this.options[this.selectedIndex].value;"&gt;
+    &lt;option value=""&gt;Select an action...&lt;/option&gt;
+    &lt;option value=""&gt;Home&lt;/option&gt;
+    &lt;option value=""&gt;Share&lt;/option&gt;
+    &lt;option value=""&gt;Edit&lt;/option&gt;
+    &lt;option value=""&gt;Export&lt;/option&gt;
+  &lt;/select&gt;
+&lt;/nav&gt;</pre>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Filters / Switchers</span>
+    <p class="style-guide-explanation">Used for navigating between different lists or in-page pieces of information without switching views. <strong>This currently has no proper mobile version!</strong></p>
+  </section>
+  <style>
+    .style-guide-filter-list ul li {
+      padding: 10px 5px;
+    }
+  </style>
+
+  <div class="row style-guide-filter-list">
+    <div class="block_3">      
+      <button data-list="0" class="filter filter_statistic filter_active">
+        <span class="statistic_number">5</span>
+        <span class="statistic_text"><strong>Tum laborum</strong></span>
+      </button>
+
+      <button data-list="1" class="filter filter_statistic">
+        <span class="statistic_number">4</span>
+        <span class="statistic_text">accusamus quos possimus</span>
+      </button>
+    </div>
+
+    <div class="block_9 block_padding">
+      <ul id="list-0" class="list list_table list_filter list_filter_active">
+        <li class="list_row">Lorem ipsum dolor sit amet</li>
+        <li class="list_row">consectetur adipisicing elit</li>
+        <li class="list_row">Ea amet iusto ab nisi numquam</li>
+        <li class="list_row">Tum laborum fugit labore dolorem</li>
+        <li class="list_row">quam nemo accusamus quos possimus</li>
+      </ul>
+
+      <ul id="list-1" class="list list_table list_filter">
+        <li class="list_row">Ea amet iusto ab nisi numquam</li>
+        <li class="list_row">Tum laborum fugit labore dolorem</li>
+        <li class="list_row">Lorem ipsum dolor sit amet</li>
+        <li class="list_row">quam nemo accusamus quos possimus</li>
+      </ul>
+    </div>
+  </div>
+
+  <pre class="style-guide-code">
+&lt;div class="row"&gt;
+  &lt;div class="block_3"&gt;      
+    &lt;button data-list="0" class="filter filter_statistic filter_active"&gt;
+      &lt;span class="statistic_number"&gt;5&lt;/span&gt;
+      &lt;span class="statistic_text"&gt;&lt;strong&gt;Tum laborum&lt;/strong&gt;&lt;/span&gt;
+    &lt;/button&gt;
+
+    &lt;button data-list="1" class="filter filter_statistic"&gt;
+      &lt;span class="statistic_number"&gt;4&lt;/span&gt;
+      &lt;span class="statistic_text"&gt;accusamus quos possimus&lt;/span&gt;
+    &lt;/button&gt;
+  &lt;/div&gt;
+
+  &lt;div class="block_9 block_padding"&gt;
+    &lt;ul id="list-0" class="list list_table list_filter list_filter_active"&gt;
+      &lt;li class="list_row"&gt;Lorem ipsum dolor sit amet&lt;/li&gt;
+      &lt;li class="list_row"&gt;consectetur adipisicing elit&lt;/li&gt;
+      &lt;li class="list_row"&gt;Ea amet iusto ab nisi numquam&lt;/li&gt;
+      &lt;li class="list_row"&gt;Tum laborum fugit labore dolorem&lt;/li&gt;
+      &lt;li class="list_row"&gt;quam nemo accusamus quos possimus&lt;/li&gt;
+    &lt;/ul&gt;
+
+    &lt;ul id="list-1" class="list list_table list_filter"&gt;
+      &lt;li class="list_row"&gt;Ea amet iusto ab nisi numquam&lt;/li&gt;
+      &lt;li class="list_row"&gt;Tum laborum fugit labore dolorem&lt;/li&gt;
+      &lt;li class="list_row"&gt;Lorem ipsum dolor sit amet&lt;/li&gt;
+      &lt;li class="list_row"&gt;quam nemo accusamus quos possimus&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+
+  <section class="style-guide-section">
+    <span class="style-guide-header">Lists</span>
+    <p class="style-guide-explanation"></p>
+  </section>
+
+  <p><strong>Basic list</strong></p>
+  <ul class="list list_table">
+    <li class="list_row">
+      Something in a <code>.list_row</code>
+    </li>
+    <li class="list_row">
+      Something in a <code>.list_row</code>
+    </li>
+    <li class="list_row">
+      Something in a <code>.list_row</code>
+    </li>
+    <li class="list_row">
+      Something in a <code>.list_row</code>
+    </li>
+    <li class="list_row">
+      Something in a <code>.list_row</code>
+    </li>  
+  </ul>
+  <pre class="style-guide-code">
+&lt;ul class="list list_table"&gt;
+  &lt;li class="list_row"&gt;
+    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+  &lt;/li&gt;
+  &lt;li class="list_row"&gt;
+    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+  &lt;/li&gt;
+  &lt;li class="list_row"&gt;
+    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+  &lt;/li&gt;
+  &lt;li class="list_row"&gt;
+    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+  &lt;/li&gt;
+  &lt;li class="list_row"&gt;
+    <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+  &lt;/li&gt;  
+&lt;/ul&gt;
+  </pre>
+
+  <p><strong>List with blocks</strong></p>
+  <ul class="list list_table">
+    <li class="list_row">
+      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+    </li>
+    <li class="list_row">
+      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+    </li>
+    <li class="list_row">
+      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+    </li>
+    <li class="list_row">
+      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+    </li>
+    <li class="list_row">
+      <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+      <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+    </li>  
+  </ul>
+
+
+
+
+</div>
+
+{% endblock %}

--- a/app/templates/style-guide/alerts.html
+++ b/app/templates/style-guide/alerts.html
@@ -1,0 +1,25 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Alerts</span>
+  <p class="style-guide-explanation">Alerts are used for user feedback based on success or errors. They are <code>&lt;ul&gt;</code>'s with the <code>.alert_list</code> class and a modifying class for success and failure (see below). They are mostly injected via the jinja templates, which means there is no way to load them via javascript right now.</p>
+</section>
+
+<ul class="alert_list alert_success">
+  <li>Success! <code>.alert_success</code></li>
+  <li>You can have multiple messages in one alert.</li>
+  <li>One more.</li>
+</ul>
+
+<ul class="alert_list alert_error">
+  <li>Error! <code>.alert_error</code></li>
+</ul>
+
+<pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;!-- success --&gt;</span>
+&lt;ul class="alert_list alert_success"&gt;
+&lt;li&gt;Success!&lt;/li&gt;
+&lt;/ul&gt;
+
+<span class="style-guide-code-comment">&lt;!-- error --&gt;</span>
+&lt;ul class="alert_list alert_error"&gt;
+&lt;li&gt;Error!&lt;/li&gt;
+&lt;/ul&gt;</pre>

--- a/app/templates/style-guide/blocks.html
+++ b/app/templates/style-guide/blocks.html
@@ -1,0 +1,35 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Blocks</span>
+  <p class="style-guide-explanation">Blocks are the essential dividers used in the application. They can be used for major layouts or small components. They are floating elements, so make sure to wrap them within a <code>.row</code> element for a proper clearfix. All blocks are styled <code>box-sizing: border-box</code> so padding and margins are added inwards, not outwards.</p>
+</section>
+<style>
+  .style-guide-block {
+    background: #f6f6f6;
+    height: 200px;
+    border: 1px solid #fff;
+  }
+</style>
+<div class="row">
+  <div class="block_8 style-guide-block"><code>.block_8</code></div>
+  <div class="block_4 style-guide-block"><code>.block_4</code></div>
+</div>
+
+<div class="row">
+  <div class="block_6 style-guide-block block_padding"><code>.block_6 block_padding</code></div>
+  <div class="block_6 style-guide-block block_padding"><code>.block_6 block_padding</code></div>
+</div>
+
+<div class="row">
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+  <div class="block_1 style-guide-block"><code>.block_1</code></div>
+</div>

--- a/app/templates/style-guide/buttons.html
+++ b/app/templates/style-guide/buttons.html
@@ -1,0 +1,54 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Buttons</span>
+  <p class="style-guide-explanation"></p>
+</section>
+
+<a class="button button_small"><code>.button_small</code></a>
+<a class="button button_small button_black"><code>.button_small</code></a>
+<a class="button button_small button_blue"><code>.button_small</code></a>
+<a class="button button_small button_red"><code>.button_small</code></a>
+<a class="button button_small button_green"><code>.button_small</code></a>
+<a class="button button_small button_brightgreen"><code>.button_small</code></a>
+<br>
+
+<a class="button"><code>.button</code></a>
+<a class="button button_black"><code>.button_black</code></a>
+<a class="button button_blue"><code>.button_blue</code></a>
+<a class="button button_red"><code>.button_red</code></a>
+<a class="button button_green"><code>.button_green</code></a>
+<a class="button button_brightgreen"><code>.button_brightgreen</code></a>
+<br>
+
+<a class="button button_fat"><code>.button_fat</code></a>
+<a class="button button_fat button_black"><code>.button_fat</code></a>
+<a class="button button_fat button_blue"><code>.button_fat</code></a>
+<a class="button button_fat button_red"><code>.button_fat</code></a>
+<a class="button button_fat button_green"><code>.button_fat</code></a>
+<a class="button button_fat button_brightgreen"><code>.button_fat</code></a>
+<br>
+
+<a class="button button_large"><code>.button_large</code></a>
+<a class="button button_large button_black"><code>.button_large</code></a>
+<a class="button button_large button_blue"><code>.button_large</code></a>
+<a class="button button_large button_red"><code>.button_large</code></a>
+<a class="button button_large button_green"><code>.button_large</code></a>
+<a class="button button_large button_brightgreen"><code>.button_large</code></a>
+<br>
+
+<a class="button button_inverse"><code>.button</code></a>
+<a class="button button_inverse button_black"><code>.button_black</code></a>
+<a class="button button_inverse button_blue"><code>.button_blue</code></a>
+<a class="button button_inverse button_red"><code>.button_red</code></a>
+<a class="button button_inverse button_green"><code>.button_green</code></a>
+<a class="button button_inverse button_brightgreen"><code>.button_brightgreen</code></a>
+<br>
+
+<a class="button button_error"><code>.button_error</code></a>
+<a class="button button_warning"><code>.button_warning</code></a>
+<a class="button button_success"><code>.button_success</code></a>
+<a class="button button_new"><code>.button_new</code></a>
+<br>
+
+<a class="button button_add button_green"><code>.button_add</code></a>
+<a class="button button_right button_brightgreen"><code>.button_right</code></a>
+<br>

--- a/app/templates/style-guide/checkboxes.html
+++ b/app/templates/style-guide/checkboxes.html
@@ -1,0 +1,196 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Checkboxes & Radios</span>
+  <p class="style-guide-explanation">Checkboxes are the main constructer here, with radio buttons piggy-backing on the styles and using the same classes.</p>
+</section>
+
+<p><strong>Checkboxes</strong></p>
+
+<label class="field_checkbox checkbox_small">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_small</code></span>
+  </span>
+</label>
+<label class="field_checkbox checkbox_small checkbox_blue">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_blue</code></span>
+  </span>
+</label>
+<label class="field_checkbox checkbox_small checkbox_green">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_green</code></span>
+  </span>
+</label>
+<label class="field_checkbox checkbox_small checkbox_red">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_red</code></span>
+  </span>
+</label>
+
+<br><br>
+
+<label class="field_checkbox">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.field_checkbox</code></span>
+  </span>
+</label>
+<label class="field_checkbox checkbox_blue">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_blue</code></span>
+  </span>
+</label>
+<label class="field_checkbox checkbox_green">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_green</code></span>
+  </span>
+</label>
+<label class="field_checkbox checkbox_red">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_red</code></span>
+  </span>
+</label>
+
+<br><br>
+
+<label class="field_checkbox checkbox_extra">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_extra</code></span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+
+<label class="field_checkbox checkbox_extra checkbox_blue">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_extra</code></span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+
+<label class="field_checkbox checkbox_extra checkbox_green">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_extra</code></span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+
+<label class="field_checkbox checkbox_extra checkbox_red">
+  <input type="checkbox" class="text" value="1" name="services" checked="true">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title"><code>.checkbox_extra</code></span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+
+<pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;-- checkbox --&gt;</span>
+&lt;label class="field_checkbox"&gt;
+&lt;input type="checkbox" class="text" value="1" name="services" checked="true"&gt;
+&lt;span class="field_checkbox_content"&gt;
+  &lt;span class="field_checkbox_content_title"&gt;TEXT&lt;/span&gt;
+&lt;/span&gt;
+&lt;/label&gt;
+
+<span class="style-guide-code-comment">&lt;-- checkbox extra --&gt;</span>
+&lt;label class="field_checkbox checkbox_extra checkbox_red"&gt;
+&lt;input type="checkbox" class="text" value="1" name="services" checked="true"&gt;
+&lt;span class="field_checkbox_content"&gt;
+  &lt;span class="field_checkbox_content_title"&gt;&lt;code&gt;TEXT&lt;/code&gt;&lt;/span&gt;
+  &lt;span class="field_checkbox_content_text"&gt;Extra text&lt;/span&gt;
+&lt;/span&gt;
+&lt;/label&gt;</pre>
+
+<br>
+<p><strong>Radio buttons</strong></p>
+
+<label class="field_radio checkbox_small checkbox_blue">
+  <input type="radio" class="text" value="1" name="Do you have health insurance?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">Yes</span>
+  </span>
+</label>
+<label class="field_radio checkbox_small checkbox_blue">
+  <input type="radio" class="text" value="1" name="Do you have health insurance?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">No</span>
+  </span>
+</label>
+<label class="field_radio checkbox_small checkbox_blue">
+  <input type="radio" class="text" value="1" name="Do you have health insurance?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">Not Sure</span>
+  </span>
+</label>
+
+<br><br>
+
+<label class="field_radio checkbox_green">
+  <input type="radio" class="text" value="1" name="Do you like pizza?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">Yes</span>
+  </span>
+</label>
+<label class="field_radio checkbox_green">
+  <input type="radio" class="text" value="1" name="Do you like pizza?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">No</span>
+  </span>
+</label>
+<label class="field_radio checkbox_green">
+  <input type="radio" class="text" value="1" name="Do you like pizza?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">Not Sure</span>
+  </span>
+</label>
+
+<br><br>
+
+<label class="field_radio checkbox_extra checkbox_red">
+  <input type="radio" class="text" value="1" name="What do you need?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">Yes</span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+<label class="field_radio checkbox_extra checkbox_red">
+  <input type="radio" class="text" value="1" name="What do you need?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">No</span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+<label class="field_radio checkbox_extra checkbox_red">
+  <input type="radio" class="text" value="1" name="What do you need?">
+  <span class="field_checkbox_content">
+    <span class="field_checkbox_content_title">Not Sure</span>
+    <span class="field_checkbox_content_text">Lorem ipsum dolor sit amet, consectetur <a href="#">adipisicing</a> elit, sed do eiusmod</span>
+  </span>
+</label>
+
+<pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;-- radio button --&gt;</span>
+&lt;label class="field_radio"&gt;
+&lt;input type="radio" class="text" value="1" name="NAME"&gt;
+&lt;span class="field_checkbox_content"&gt;
+  &lt;span class="field_checkbox_content_title"&gt;TEXT&lt;/span&gt;
+&lt;/span&gt;
+&lt;/label&gt;
+
+<span class="style-guide-code-comment">&lt;-- radio button extra --&gt;</span>
+&lt;label class="field_radio checkbox_extra checkbox_red"&gt;
+&lt;input type="radio" class="text" value="1" name="NAME"&gt;
+&lt;span class="field_checkbox_content"&gt;
+  &lt;span class="field_checkbox_content_title"&gt;TEXT&lt;/span&gt;
+  &lt;span class="field_checkbox_content_text"&gt;More text&lt;/span&gt;
+&lt;/span&gt;
+&lt;/label&gt;
+</pre>

--- a/app/templates/style-guide/colors.html
+++ b/app/templates/style-guide/colors.html
@@ -1,0 +1,23 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Colors</span>
+  <p class="style-guide-explanation"></p>
+</section>
+<style>
+  .style-guide-color-block {
+    padding: 1em;
+    height: 100px;
+    border: 1px solid white;
+  }
+</style>
+<div class="row">
+  <div class="color-black block_3 style-guide-color-block"><code style="color: white;">.color-black</code></div>
+  <div class="color-white block_3 style-guide-color-block"><code>.color-white</code></div>
+  <div class="color-lightgray block_3 style-guide-color-block"><code>.color-lightgray</code></div>
+  <div class="color-gray block_3 style-guide-color-block"><code>.color-gray</code></div>
+  <div class="color-darkgray block_3 style-guide-color-block"><code>.color-darkgray</code></div>
+  <div class="color-blue block_3 style-guide-color-block"><code>.color-blue</code></div>
+  <div class="color-red block_3 style-guide-color-block"><code>.color-red</code></div>
+  <div class="color-green block_3 style-guide-color-block"><code>.color-green</code></div>
+  <div class="color-fuscia block_3 style-guide-color-block"><code>.color-fuscia</code></div>
+  <div class="color-brightgreen block_3 style-guide-color-block"><code>.color-brightgreen</code></div>
+</div>

--- a/app/templates/style-guide/filters.html
+++ b/app/templates/style-guide/filters.html
@@ -1,0 +1,72 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Filters / Switchers</span>
+  <p class="style-guide-explanation">Used for navigating between different lists or in-page pieces of information without switching views. <strong>This currently has no proper mobile version!</strong></p>
+</section>
+<style>
+  .style-guide-filter-list ul li {
+    padding: 10px 5px;
+  }
+</style>
+
+<div class="row style-guide-filter-list">
+  <div class="block_3">      
+    <button data-list="0" class="filter filter_statistic filter_active">
+      <span class="statistic_number">5</span>
+      <span class="statistic_text"><strong>Tum laborum</strong></span>
+    </button>
+
+    <button data-list="1" class="filter filter_statistic">
+      <span class="statistic_number">4</span>
+      <span class="statistic_text">accusamus quos possimus</span>
+    </button>
+  </div>
+
+  <div class="block_9 block_padding">
+    <ul id="list-0" class="list list_table list_filter list_filter_active">
+      <li class="list_row">Lorem ipsum dolor sit amet</li>
+      <li class="list_row">consectetur adipisicing elit</li>
+      <li class="list_row">Ea amet iusto ab nisi numquam</li>
+      <li class="list_row">Tum laborum fugit labore dolorem</li>
+      <li class="list_row">quam nemo accusamus quos possimus</li>
+    </ul>
+
+    <ul id="list-1" class="list list_table list_filter">
+      <li class="list_row">Ea amet iusto ab nisi numquam</li>
+      <li class="list_row">Tum laborum fugit labore dolorem</li>
+      <li class="list_row">Lorem ipsum dolor sit amet</li>
+      <li class="list_row">quam nemo accusamus quos possimus</li>
+    </ul>
+  </div>
+</div>
+
+<pre class="style-guide-code">
+&lt;div class="row"&gt;
+&lt;div class="block_3"&gt;      
+  &lt;button data-list="0" class="filter filter_statistic filter_active"&gt;
+    &lt;span class="statistic_number"&gt;5&lt;/span&gt;
+    &lt;span class="statistic_text"&gt;&lt;strong&gt;Tum laborum&lt;/strong&gt;&lt;/span&gt;
+  &lt;/button&gt;
+
+  &lt;button data-list="1" class="filter filter_statistic"&gt;
+    &lt;span class="statistic_number"&gt;4&lt;/span&gt;
+    &lt;span class="statistic_text"&gt;accusamus quos possimus&lt;/span&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
+
+&lt;div class="block_9 block_padding"&gt;
+  &lt;ul id="list-0" class="list list_table list_filter list_filter_active"&gt;
+    &lt;li class="list_row"&gt;Lorem ipsum dolor sit amet&lt;/li&gt;
+    &lt;li class="list_row"&gt;consectetur adipisicing elit&lt;/li&gt;
+    &lt;li class="list_row"&gt;Ea amet iusto ab nisi numquam&lt;/li&gt;
+    &lt;li class="list_row"&gt;Tum laborum fugit labore dolorem&lt;/li&gt;
+    &lt;li class="list_row"&gt;quam nemo accusamus quos possimus&lt;/li&gt;
+  &lt;/ul&gt;
+
+  &lt;ul id="list-1" class="list list_table list_filter"&gt;
+    &lt;li class="list_row"&gt;Ea amet iusto ab nisi numquam&lt;/li&gt;
+    &lt;li class="list_row"&gt;Tum laborum fugit labore dolorem&lt;/li&gt;
+    &lt;li class="list_row"&gt;Lorem ipsum dolor sit amet&lt;/li&gt;
+    &lt;li class="list_row"&gt;quam nemo accusamus quos possimus&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/div&gt;
+&lt;/div&gt;</pre>

--- a/app/templates/style-guide/forms.html
+++ b/app/templates/style-guide/forms.html
@@ -1,0 +1,4 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Forms</span>
+  <p class="style-guide-explanation"></p>
+</section>

--- a/app/templates/style-guide/lists.html
+++ b/app/templates/style-guide/lists.html
@@ -1,0 +1,66 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Lists</span>
+  <p class="style-guide-explanation"></p>
+</section>
+
+<p><strong>Basic list</strong></p>
+<ul class="list list_table">
+  <li class="list_row">
+    Something in a <code>.list_row</code>
+  </li>
+  <li class="list_row">
+    Something in a <code>.list_row</code>
+  </li>
+  <li class="list_row">
+    Something in a <code>.list_row</code>
+  </li>
+  <li class="list_row">
+    Something in a <code>.list_row</code>
+  </li>
+  <li class="list_row">
+    Something in a <code>.list_row</code>
+  </li>  
+</ul>
+<pre class="style-guide-code">
+&lt;ul class="list list_table"&gt;
+&lt;li class="list_row"&gt;
+  <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+&lt;/li&gt;
+&lt;li class="list_row"&gt;
+  <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+&lt;/li&gt;
+&lt;li class="list_row"&gt;
+  <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+&lt;/li&gt;
+&lt;li class="list_row"&gt;
+  <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+&lt;/li&gt;
+&lt;li class="list_row"&gt;
+  <span class="style-guide-code-comment">&lt;-- put anything here --&gt;</span>
+&lt;/li&gt;  
+&lt;/ul&gt;
+</pre>
+
+<p><strong>List with blocks</strong></p>
+<ul class="list list_table">
+  <li class="list_row">
+    <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+    <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+  </li>
+  <li class="list_row">
+    <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+    <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+  </li>
+  <li class="list_row">
+    <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+    <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+  </li>
+  <li class="list_row">
+    <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+    <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+  </li>
+  <li class="list_row">
+    <span class="block_4" style="padding:10px;">This is within a <code>.block_4</code></span>
+    <span class="block_8" style="padding:10px;">This more information within a <code>.block_8</code></span>
+  </li>  
+</ul>

--- a/app/templates/style-guide/maps.html
+++ b/app/templates/style-guide/maps.html
@@ -1,0 +1,39 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Maps</span>
+  <p class="style-guide-explanation">Maps require two parts. 1) The locations, which are derived from a <code>.location</code> element and its attributes. There also needs to be a map object for the actual map to show up with the <code>#service-map</code> ID. The location components and the map object are decoupled, and therefore can exist in different parts of the page and continue to work.</p>
+</section>
+
+<div class="service_locations">
+
+  <h3>Location(s)</h3>
+  <div class="location" data-name="The Daily Planet" data-address="517 W Grace St. Richmond, VA 23220" data-latitude="37.547508" data-longitude="-77.447895">
+    <i class="fa fa-map-marker"></i>
+    <span class="location_name"><strong>The Daily Planet</strong></span>
+    <span class="location_address">517 W Grace St. Richmond, VA 23220</span> 
+  </div>
+
+  <div class="location" data-name="Southside Community Health Center" data-address="180 Belt Blvd. Richmond, VA 23225" data-latitude="37.509781" data-longitude="-77.487185">
+    <i class="fa fa-map-marker"></i>
+    <span class="location_name"><strong>Southside Community Health Center</strong></span>
+    <span class="location_address">180 Belt Blvd. Richmond, VA 23225</span> 
+  </div>
+
+  <div class="location" data-name="St. Joseph\s Villa" data-address="8000 Brook Road, Richmond, VA 23227" data-latitude="37.632248" data-longitude="-77.459127">
+    <i class="fa fa-map-marker"></i>
+    <span class="location_name"><strong>St. Joseph\s Villa</strong></span>
+    <span class="location_address">8000 Brook Road, Richmond, VA 23227</span> 
+  </div>
+</div>
+
+<div id="service-map" style="height: 400px;"></div>
+
+<pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;-- .location element --&gt;</span>
+&lt;div class="location" data-name="NAME" data-address="ADDRESS" data-latitude="LATITUDE" data-longitude="LONGITUDE"&gt;
+&lt;i class="fa fa-map-marker"&gt;&lt;/i&gt;
+&lt;span class="location_name"&gt;&lt;strong&gt;LOCATION NAME&lt;/strong&gt;&lt;/span&gt;
+&lt;span class="location_address"&gt;LOCATION ADDRESS&lt;/span&gt; 
+&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;-- #service-map element --&gt;</span>
+&lt;div id="service-map"&gt;&lt;/div&gt;</pre>

--- a/app/templates/style-guide/notifications.html
+++ b/app/templates/style-guide/notifications.html
@@ -1,0 +1,4 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Notifications</span>
+  <p class="style-guide-explanation"></p>
+</section>

--- a/app/templates/style-guide/tabs.html
+++ b/app/templates/style-guide/tabs.html
@@ -1,0 +1,39 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Tabs</span>
+  <p class="style-guide-explanation">Tabs are used to shuffle between related views, such as a patient's information, sharing that patient, etc. The mobile version of tabs turns into a <code>select</code> field that, when selected, brings the user to the new view. These are typically generated in jinja templates.</p>
+</section>
+
+<nav class="nav_tabs">
+  <div class="tabs">
+    <a class="tab tab_active" href="/patient_details/2"><i class="fa fa-home"></i> Home</a>
+    <a class="tab" href=""><i class="fa fa-share"></i> Share</a>
+    <a class="tab" href=""><i class="fa fa-pencil"></i> Edit</a>
+    <a class="tab" href=""><i class="fa fa-download"></i> Export</a>
+  </div>
+
+  <select class="tabs_dropdown" onchange="location = this.options[this.selectedIndex].value;">
+    <option value="">Select an action...</option>
+    <option value="">Home</option>
+    <option value="">Share</option>
+    <option value="">Edit</option>
+    <option value="">Export</option>
+  </select>
+</nav>
+
+<pre class="style-guide-code">
+&lt;nav class="nav_tabs"&gt;
+&lt;div class="tabs"&gt;
+  &lt;a class="tab tab_active" href="/patient_details/2"&gt;&lt;i class="fa fa-home"&gt;&lt;/i&gt; Home&lt;/a&gt;
+  &lt;a class="tab" href=""&gt;&lt;i class="fa fa-share"&gt;&lt;/i&gt; Share&lt;/a&gt;
+  &lt;a class="tab" href=""&gt;&lt;i class="fa fa-pencil"&gt;&lt;/i&gt; Edit&lt;/a&gt;
+  &lt;a class="tab" href=""&gt;&lt;i class="fa fa-download"&gt;&lt;/i&gt; Export&lt;/a&gt;
+&lt;/div&gt;
+
+&lt;select class="tabs_dropdown" onchange="location = this.options[this.selectedIndex].value;"&gt;
+  &lt;option value=""&gt;Select an action...&lt;/option&gt;
+  &lt;option value=""&gt;Home&lt;/option&gt;
+  &lt;option value=""&gt;Share&lt;/option&gt;
+  &lt;option value=""&gt;Edit&lt;/option&gt;
+  &lt;option value=""&gt;Export&lt;/option&gt;
+&lt;/select&gt;
+&lt;/nav&gt;</pre>

--- a/app/templates/style-guide/tooltips.html
+++ b/app/templates/style-guide/tooltips.html
@@ -1,0 +1,35 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Tooltips</span>
+  <p class="style-guide-explanation">Tooltips are used to add extra information to an element in the page. This information should not be priority to the user in order to interact with the app properly!</p>
+</section>
+<style>
+  .style-guide-tooltip {
+    max-width: 400px;
+    height: 100px;
+    background: #f6f6f6;
+    display: block;
+    margin: auto;
+    padding: 10px;
+  }
+</style>
+
+<div class="tooltip tooltip_right style-guide-tooltip" value="Here's a tip - drink water."><code>.tooltip.tooltip_right</code></div><br>
+
+<div class="tooltip tooltip_left style-guide-tooltip" value="How is your day going?"><code>.tooltip.tooltip_left</code></div><br>
+
+<div class="tooltip tooltip_top style-guide-tooltip" value="Life's greatest treasure is hidden."><code>.tooltip.tooltip_top</code></div><br>
+
+<div class="tooltip tooltip_bottom style-guide-tooltip" value="Arrrrr. Give me your gold dabloons!"><code>.tooltip.tooltip_bottom</code></div><br>
+
+<pre class="style-guide-code">
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_right --&gt;</span>
+&lt;div class="tooltip tooltip_right" value="Here's a tip - drink water."&gt;&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_left --&gt;</span>
+&lt;div class="tooltip tooltip_left" value="How is your day going?"&gt;&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_top --&gt;</span>
+&lt;div class="tooltip tooltip_top" value="Life's greatest treasure is hidden."&gt;&lt;/div&gt;
+
+<span class="style-guide-code-comment">&lt;!-- tooltip tooltip_bottom --&gt;</span>
+&lt;div class="tooltip tooltip_bottom" value="Arrrrr. Give me your gold dabloons!"&gt;&lt;/div&gt;</pre>

--- a/app/templates/style-guide/typography.html
+++ b/app/templates/style-guide/typography.html
@@ -1,0 +1,14 @@
+<section class="style-guide-section">
+  <span class="style-guide-header">Text, headings, links</span>
+  <p class="style-guide-explanation"></p>
+</section>
+
+<h1>Header 1</h1>
+<h2>Header 2</h2>
+<h3>Header 3</h3>
+<h4>Header 4</h4>
+<h1><a href="">Header 1 with link</a></h1>
+<h2><a href="">Header 2 with link</a></h2>
+<h3><a href="">Header 3 with link</a></h3>
+<h4><a href="">Header 4 with link</a></h4>
+<p>Lorem ipsum dolor sit amet, <strong>strong text</strong> elit. Sed tincidunt semper diam non mattis. Nullam non facilisis ex, in sollicitudin turpis. Pellentesque in mattis ex, id porta dui. Suspendisse non accumsan risus. Duis consequat nunc lacinia arcu consequat, eu elementum purus congue. <a href="">Text with a link</a> vehicula blandit diam sit amet tristique. Duis hendrerit dui eros, a scelerisque lacus placerat ornare. Nam ultricies, nisi vitae commodo consectetur, ligula odio pellentesque justo, eu varius mauris ipsum lobortis erat. Nullam scelerisque imperdiet ipsum, et malesuada tellus convallis quis. Donec condimentum tempor urna id accumsan. Suspendisse tempor iaculis urna ut efficitur. Nulla auctor dolor in velit vulputate iaculis. Maecenas tincidunt erat quis rutrum eleifend.</p>

--- a/app/views.py
+++ b/app/views.py
@@ -618,3 +618,8 @@ def template_prototyping():
 @login_required
 def mockup():
     return render_template('MOCKUPS.html')
+
+@screener.route('/style-guide')
+@login_required
+def style_guide():
+    return render_template('style-guide.html')

--- a/front/js/session_monitor.js
+++ b/front/js/session_monitor.js
@@ -55,7 +55,6 @@ sessionMonitor = function(options) {
     function extendsess() {
         // Extend the session expiration. Ping the server and reset the timers if
         // the minimum interval has passed since the last ping.
-        debugger;
         var now = $.now(),
             timeSinceLastPing = now - _lastPingTime;
 

--- a/front/sass/components/buttons.scss
+++ b/front/sass/components/buttons.scss
@@ -13,10 +13,8 @@
 @mixin button_color($color, $text: $color-white) {
   color: $text;
   background: $color;
-  border: 1px solid $color;
   &:hover {
     background: darken($color, 10);
-    border: 1px solid darken($color, 10);
   }
   &.button_inverse {
     color: $color;
@@ -75,9 +73,11 @@
   &.button_black {
     @include button_color($button-color-black);
   }
+  &.button_new,
   &.button_blue {
     @include button_color($button-color-blue);
   }
+  &.button_success,
   &.button_green {
     @include button_color($button-color-green);
   }

--- a/front/sass/components/tooltips.scss
+++ b/front/sass/components/tooltips.scss
@@ -78,7 +78,7 @@
   &.tooltip_top {
     &:hover {
       &:before {
-        top: $tooltip-tb-zero;
+        top: $tooltip-tb-zero + 1px;
         margin-top: $tooltip-tb-margin-box;
       }
       &:after {
@@ -92,7 +92,7 @@
   &.tooltip_bottom {
     &:hover {
       &:before {
-        bottom: $tooltip-tb-zero;
+        bottom: $tooltip-tb-zero + 1px;
         margin-bottom: $tooltip-tb-margin-box;
       }
       &:after {

--- a/front/sass/variables.scss
+++ b/front/sass/variables.scss
@@ -43,6 +43,27 @@ $color-green: #3D9970;
 $color-fuscia: #c71e56;
 $color-brightgreen: #2ecc40;
 
+.color-black {
+  background-color: $color-black; }
+.color-white {
+  background-color: $color-white; }
+.color-gray {
+  background-color: $color-gray; }
+.color-darkgray {
+  background-color: $color-darkgray; }
+.color-lightgray {
+  background-color: $color-lightgray; }
+.color-blue {
+  background-color: $color-blue; }
+.color-red {
+  background-color: $color-red; }
+.color-green {
+  background-color: $color-green; }
+.color-fuscia {
+  background-color: $color-fuscia; }
+.color-brightgreen {
+  background-color: $color-brightgreen; }
+
 /* * * * * * * * 
 **
 ** UI - General


### PR DESCRIPTION
Adds a new route `/style-guide` to the app so we can view all of our visual components together.

Makes some minor changes to styles and removes a `debugger;` statement from the `session_monitor.js` file.

Example guide:

<img width="1173" alt="screen shot 2015-09-09 at 3 30 14 pm" src="https://cloud.githubusercontent.com/assets/1943001/9775874/b67ae4f4-5707-11e5-9c76-dbe978b5cb7a.png">
