### PR TITLE
update search to work on ie9+, styles updated to be more user friendly

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html {{ _('lang="en"') }}>
   {% include "includes/head.html" %}
   <body>
@@ -12,9 +13,9 @@
     <script>
     window.onload = init();
     function init() {
-      window.App = new AppController({
-        foo: 'bar'
-      });
+      // window.App = new AppController({
+      //   foo: 'bar'
+      // });
 
       window.menu = new Menu({
         id: 'nav'

--- a/front/js/search.js
+++ b/front/js/search.js
@@ -77,7 +77,7 @@ var templates = {
   },
   list: function(data) {
     var elem = document.createElement('ul');
-    elem.className = 'list list_table';
+    elem.className = 'list list_table list_search';
     for (var p = 0; p < data.patients.length; p++) {
       var patient = data.patients[p];
       var li = document.createElement('li');
@@ -85,36 +85,37 @@ var templates = {
       
       var anchor = document.createElement('a');
       anchor.href = patient.url;
-      anchor.innerHTML += '<span class="list_row_item list_row_name">' + patient.fname + ' ' + patient.lname + '</span>';
-      anchor.innerHTML += '<span class="list_row_item list_row_dob">' + patient.dob + '</span>';
-      anchor.innerHTML += '<span class="list_row_item list_row_edits">' + patient.created + '</span>';
+      anchor.innerHTML += '<div class="block_3 patient_search_result_item">' + patient.fname + '</div>';
+      anchor.innerHTML += '<div class="block_3 patient_search_result_item">' + patient.lname + '</div>';
+      anchor.innerHTML += '<div class="block_3 patient_search_result_item">' + patient.dob + '</div>';
+      anchor.innerHTML += '<div class="block_3 patient_search_result_item">' + patient.ssn + '</div>';
 
       li.appendChild(anchor);
       elem.appendChild(li);
     }
-    var newPatient = document.createElement('a');
-    newPatient.href = newPatientUrl;
-    newPatient.innerHTML = '<i class="fa fa-plus"></i> Not the right <strong>' + data.none[0].name + '</strong>? Add them as a new patient.';
 
-    var addNew = document.createElement('li');
-    addNew.className = 'list_row list_row_addnew';
-    addNew.appendChild(newPatient);
-    elem.appendChild(addNew);
+
+    var newPatient = document.createElement('li');
+    newPatient.href = newPatientUrl;
+    newPatient.innerHTML = '<div class="block_12"><button class="button button_blue button_large patient_search_button" type="submit">Add <strong>' + data.none[0].name + '</strong> as a new patient</button></div>';
+    elem.appendChild(newPatient);
 
     return elem;
   },
   noresults: function(data) {
-    var elem = document.createElement('div');
-    elem.className = 'no_results';
-    elem.innerHTML = '<p><i class="fa fa-exclamation-circle"></i> No patients matched <strong>' + data.none[0].name + '</strong></p>';
+    var elem = document.createElement('ul');
+    elem.className = 'list list_table list_search';
     
-    var newPatient = document.createElement('button');
-    newPatient.className = 'button button_blue button_fat button_add';
-    newPatient.setAttribute('type', 'submit');
-    // newPatient.href = newPatientUrl || '/new_patient';
-    newPatient.innerHTML = 'Create a new patient record with ' + data.none[0].name;
-    
+    var li = document.createElement('li');
+    li.className = 'list_row'
+    elem.innerHTML = '<div class="block_12 patient_search_result_item patient_search_noresults"><i class="fa fa-exclamation-circle"></i> No patients matched <strong>' + data.none[0].name + '</strong></div>';    
+    elem.appendChild(li);
+
+    var newPatient = document.createElement('li');
+    newPatient.href = newPatientUrl;
+    newPatient.innerHTML = '<div class="block_12"><button class="button button_blue button_large patient_search_button" type="submit">Add <strong>' + data.none[0].name + '</strong> as a new patient</button></div>';
     elem.appendChild(newPatient);
+  
     return elem;
   }
 };

--- a/front/sass/patient/listings.scss
+++ b/front/sass/patient/listings.scss
@@ -39,7 +39,7 @@ $list-padding-large: 1em;
     a {
       display:block;
       @include clearfix();
-      padding: $list-padding;
+      // padding: $list-padding;
       color: black;
     }
     span {
@@ -122,31 +122,6 @@ $list-padding-large: 1em;
         padding: $list-padding-large $list-padding;
       }
     }
-  }
-}
-
-.list_row_name {
-  color: $color-fuscia;
-  @media (min-width: $break) {
-    width: 25%;
-  }
-}
-
-.list_row_dob {
-  font-weight: 100;
-  color: $color-gray;
-  font-family: monospace;
-  @media (min-width: $break) {
-    width: 20%;
-  }
-}
-
-.list_row_edits {
-  color: $color-black;
-  font-size: 0.9em;
-  @media (min-width: $break) {
-    text-align: right;
-    width: 55%;
   }
 }
 

--- a/front/sass/patient/search.scss
+++ b/front/sass/patient/search.scss
@@ -5,10 +5,6 @@
   margin-bottom: 1em;
 }
 
-.patient_search_form {
-  margin-bottom: 1.5em;
-}
-
 .search_results {}
 
 .button_add_new_patient {
@@ -24,6 +20,35 @@
     width: auto;
   }
 }
+
+.list_search {
+  .list_row {
+    opacity: 0.5;
+    &:hover {
+      opacity: 1;
+      background: transparent;
+    }
+  }
+  .patient_search_result_item {
+    font-size: 1.6em;
+    background: white;
+    border: 1px solid #c0c0c0;
+    padding: 0.4em;
+    margin-top: -1px;
+    &:not(:first-child) {
+      margin-left: -1px;
+    }
+  }
+  .patient_search_noresults {
+    background: white;
+    opacity: 0.8;
+    border: none;
+  }
+  .patient_search_button {
+    margin-top: 0;
+  }
+}
+
 
 .search_results_spinner {
   display: block;


### PR DESCRIPTION
Searching on IE broke, which is a **Huge Blocker**. This PR makes sure all JS is running properly on IE9 according to BrowserStack. It also adds some new styles to the search results, making them larger and more informative to the available search fields.

This is a search in IE9, Windows 7:

![rva-screener-search-ie9](https://cloud.githubusercontent.com/assets/1943001/10317885/93fd7c06-6c34-11e5-80a0-b1454bb73b08.gif)
