### PR TITLE
Small changes

### DIFF
--- a/app/prescreening.py
+++ b/app/prescreening.py
@@ -46,6 +46,7 @@ def calculate_pre_screen_results(
                     and sliding_scale.fpl_high is None
                 )
             ):
+                sliding_scale_id = sliding_scale.id
                 sliding_scale_name = sliding_scale.scale_name
                 sliding_scale_fees = sliding_scale.sliding_scale_fees
                 if sliding_scale.fpl_high:
@@ -66,6 +67,7 @@ def calculate_pre_screen_results(
             'residence_requirement_yn': service.residence_requirement_yn,
             'time_in_area_requirement_yn': service.time_in_area_requirement_yn,
             'sliding_scale': sliding_scale_name,
+            'sliding_scale_id': str(sliding_scale_id),
             'sliding_scale_range': sliding_scale_range,
             'sliding_scale_fees': sliding_scale_fees,
             'id': service.id

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,20 +12,20 @@
       </button> 
 
       <button data-list="1" class="filter filter_sub">
-        Completed outgoing referrals <span class="filter-count">({{ org_completed_referrals_outgoing.count() }})
+        Outgoing referrals with responses <span class="filter-count">({{ org_completed_referrals_outgoing.count() }})
         </span>
       </button>
 
       <button data-list="2" class="filter filter_sub">
-        Open outgoing referrals <span class="filter-count">({{ org_open_referrals_outgoing.count() }})</span>
+        Outgoing referrals waiting for responses <span class="filter-count">({{ org_open_referrals_outgoing.count() }})</span>
       </button>
 
       <button data-list="3" class="filter filter_sub">
-        Completed incoming referrals <span class="filter-count">({{ org_completed_referrals_incoming.count() }})</span>
+        Incoming referrals with responses <span class="filter-count">({{ org_completed_referrals_incoming.count() }})</span>
       </button>
 
       <button data-list="4" class="filter filter_sub">
-        Open incoming referrals <span class="filter-count">({{ org_open_referrals_incoming.count() }})</span>
+        Incoming referrals waiting for responses <span class="filter-count">({{ org_open_referrals_incoming.count() }})</span>
       </button>
 
       <button data-list="5" class="filter filter_sub">
@@ -36,10 +36,10 @@
         <i class="fa fa-user"></i> <strong>Your</strong> recently updated patients <span class="filter-count">({{ your_recently_updated.count() }})</span>
       </button>
       <button data-list="7" class="filter filter_sub">
-        Your completed outgoing referrals <span class="filter-count">({{ your_completed_referrals_outgoing.count() }})</span>
+        Outgoing referrals with responses <span class="filter-count">({{ your_completed_referrals_outgoing.count() }})</span>
       </button>
       <button data-list="8" class="filter filter_sub">
-        Your open outgoing referrals <span class="filter-count">({{ your_open_referrals_outgoing.count() }})</span>
+        Outgoing referrals waiting for responses <span class="filter-count">({{ your_open_referrals_outgoing.count() }})</span>
       </button>
     </div>
 
@@ -50,7 +50,7 @@
         <li class="list_row row"><a href="{{ url_for('screener.patient_overview', id=patient.id) }}">
           <div class="block_4"><strong>{{ patient.first_name }} {{ patient.last_name }}</strong></div>
           <div class="block_8">
-            <span>Created by {{ patient.created_by.full_name }} at {{ patient.created_by.service.name }}</span>
+            <span>Created by {{ patient.created_by.full_name }} at {{ patient.created_by.service.name }} on {{ patient.created.strftime('%m/%d/%Y') }}</span>
           </div>
         </a></li>
       {% endfor %}
@@ -79,7 +79,7 @@
             {% for referral in patient.referrals %}
             {% if referral.from_app_user.service.id == current_user.service.id %}
             {% if referral.status == "SENT" or referral.status == "RECEIVED" %}
-            <span>Referred to {{ referral.to_service.name }} on {{ referral.created.strftime('%m/%d/%Y') }} [{{ referral.status|lower }}]</span>
+            <span>Referred to {{ referral.to_service.name }} on {{ referral.created.strftime('%m/%d/%Y') }}</span>
             {% endif %}
             {% endif %}
             {% endfor %}
@@ -111,7 +111,7 @@
             {% for referral in patient.referrals %}
             {% if referral.to_service_id == current_user.service.id %}
             {% if referral.status == "SENT" or referral.status == "RECEIVED" %}
-            <span>From {{ referral.from_app_user.full_name }} ({{ referral.from_app_user.service.name }}) on {{ referral.created.strftime('%m/%d/%Y') }} [{{ referral.status|lower }}]</span>
+            <span>From {{ referral.from_app_user.full_name }} ({{ referral.from_app_user.service.name }}) on {{ referral.created.strftime('%m/%d/%Y') }}</span>
             {% endif %}
             {% endif %}
             {% endfor %}
@@ -125,7 +125,7 @@
         <li class="list_row row"><a href="{{ url_for('screener.patient_overview', id=patient.id) }}">
           <div class="block_4"><strong>{{ patient.first_name }} {{ patient.last_name }}</strong></div>
           <div class="block_8">
-            <span>Last updated on {{ patient.last_modified.strftime('%m/%d/%Y') }}</span>
+            <span>Last updated on {{ patient.last_modified.strftime('%m/%d/%Y') if patient.last_modified }}</span>
           </div>
         </a></li>
       {% endfor %}
@@ -136,7 +136,7 @@
         <li class="list_row row"><a href="{{ url_for('screener.patient_overview', id=patient.id) }}">
           <div class="block_4"><strong>{{ patient.first_name }} {{ patient.last_name }}</strong></div>
           <div class="block_8">
-            <span>Last updated on {{ patient.last_modified }}</span>
+            <span>Last updated on {{ patient.last_modified.strftime('%m/%d/%Y %-I:%M:%S %p') if patient.last_modified }}</span>
           </div>
         </a></li>
       {% endfor %}
@@ -165,7 +165,7 @@
             {% for referral in patient.referrals %}
             {% if referral.from_app_user_id == current_user.id %}
             {% if referral.status == "SENT" or referral.status == "RECEIVED" %}
-            <span>Referral sent to {{ referral.to_service.name }} on {{ referral.created.strftime('%m/%d/%Y') }} [{{ referral.status|lower }}]</span>
+            <span>Referral sent to {{ referral.to_service.name }} on {{ referral.created.strftime('%m/%d/%Y') }}</span>
             {% endif %}
             {% endif %}
             {% endfor %}

--- a/app/templates/patient_overview.html
+++ b/app/templates/patient_overview.html
@@ -5,70 +5,60 @@
 
 
 <ul class="patientOverview">
-  <li class="list_row">Profile created on {{ patient.created.strftime('%m/%d/%Y') }} by {{ patient.created_by.full_name }}</li>
-  {% if patient.fpl_percentage %}
+  <li class="list_row">Profile created on {{ patient.created.strftime('%m/%d/%Y') }} by {{ patient.created_by.full_name }} at {{ patient.created_by.service.name }}</li>
+
   <li class="list_row">
     Estimated Federal Poverty Level <span>% <strong>{{ '%0.2f'| format(patient.fpl_percentage|float) }}</strong></span>
   </li>
-  {% endif %}
 
-  {% if patient.total_annual_income %}
   <li class="list_row">
      Monthly Income <span><i class="fa fa-usd"></i> <strong>{{(patient.total_annual_income / 12) | int}} </strong>/ {{ _("month") }}</span>
   </li>
-  {% endif %}
 
-  {% if patient.household_members %}
   <li class="list_row">
     Household Size <span><strong>{{ patient.household_members.count() + 1 }}</strong> household members</span>
   </li>
-  {% endif %}
 
-  {% if patient.document_images %}
   <li class="list_row">
     Documents <span><strong>{{patient.document_images.count()}}</strong> documents uploaded</span>
   </li>
-  {% endif %}
 
-  {% if patient.insurance_status %}
   <li class="list_row">
-    Does {{ patient.first_name }} have insurance?
+    Insurance/VCC
     {% if patient.insurance_status == "Y" %}
-    <span>Yes</span>{% if patient.coverage_type %}, with {% if patient.coverage_type == "OTHER" %}<span>{{ patient.coverage_type_other }}</span>{% else %}<span>{{ patient.coverage_type }}</span>{% endif %}{% endif %}
+    <span>Yes</span>{% if patient.coverage_type %}, {% if patient.coverage_type == "OTHER" %}<span>{{ patient.coverage_type_other }}</span>{% else %}<span>{{ patient.coverage_type }}</span>{% endif %}{% endif %}
+    {% elif patient.insurance_status == "N" %}
+    <span>None</span>
     {% else %}
-    <span>No</span>
+    <span>No answer</span>
     {% endif %}
   </li>
-  {% endif %}
 
-  {% if patient.insurance_status %}
   <li class="list_row">
-    {{ _("Time lived in the Greater Richmond area")}} <span>{{ patient.years_living_in_area }}</span> years, <span>{{ patient.months_living_in_area }}</span> months.
+    {{ _("Time lived in the Greater Richmond area")}} {% if patient.years_living_in_area %}<span>{{ patient.years_living_in_area }}</span> years{% if patient.months_living_in_area %}, <span>{{ patient.months_living_in_area }}</span> months{% endif %}{% endif %}
   </li>
-  {% endif %}
+
 </ul>
 
 
 <h2>{{ current_user.service.name }} Eligibility</h2>
 
-{% for service in services %}
-  {% if service.id == current_user.service_id %}
-    {% if service.eligible %}
-    <div class="patientEstimation patientEstimation_eligible">
-      <p class="color-success"><i class="fa fa-check"></i> {{ patient.first_name }} {{ patient.last_name }} is <strong>likely eligible</strong> for services at {{ service.name }}</p>
-      <p><small>Results are based on FPL calculations, household size, whether or not {{ patient.first_name }} has health insurance, and if {{ patient.first_name }} is eligible for Medicaid.</small></p>
-    </div>
-    {% else %}
-    <div class="patientEstimation patientEstimation_noteligible">
-      <p class="color-success"><i class="fa fa-times"></i> {{ patient.first_name }} {{ patient.last_name }} is likely <strong>not eligible</strong> for services at {{ service.name }}</p>
-      <p><small>Results are based on FPL calculations, household size, whether or not {{ patient.first_name }} has health insurance, and if {{ patient.first_name }} is eligible for Medicaid. You can edit these details in <a href="{{ url_for('screener.patient_details', id=patient.id) }}">{{ patient.first_name}}'s patient details page.</a></small></p>
-    </div>
-    {% endif %}
-  {% endif %}
-{% endfor %}
+
+{% if service.eligible %}
+  <div class="patientEstimation patientEstimation_eligible">
+    <p class="color-success"><i class="fa fa-check"></i> {{ patient.first_name }} {{ patient.last_name }} is <strong>likely eligible</strong> for services at {{ service.name }}{% if service.sliding_scale and service.sliding_scale != 'All' %} at the <strong>{{ service.sliding_scale }}</strong> section of the sliding scale{% endif %}.</p>
+    <p><small>Results are based on FPL calculations, household size, insurance status, and Medicaid eligibility.</small></p>
+  </div>
+{% else %}
+  <div class="patientEstimation patientEstimation_noteligible">
+    <p class="color-success"><i class="fa fa-times"></i> {{ patient.first_name }} {{ patient.last_name }} is likely <strong>not eligible</strong> for services at {{ service.name }}</p>
+    <p><small>Results are based on FPL calculations, household size, insurance status, and Medicaid eligibility. You can edit these details in <a href="{{ url_for('screener.patient_details', id=patient.id) }}">{{ patient.first_name}}'s patient details page.</a></small></p>
+  </div>
+{% endif %}
+
 
 <div class="patientEligibilityForm" id="eligibility-form">
-  <p>Can you confirm or deny the above estimation? Is {{ patient.first_name }} eligible for care at {{ current_user.service.name }}? Fill out the form below to submit {{ patient.first_name }}'s eligibility status.</p>
+  <p>Can you confirm or deny this estimate? Is {{ patient.first_name }} eligible for care at {{ current_user.service.name }}? Fill out the form below to submit {{ patient.first_name }}'s eligibility status.</p>
 
   <form method="post">
     {{ form.hidden_tag() }}

--- a/app/templates/patient_screening_history.html
+++ b/app/templates/patient_screening_history.html
@@ -15,7 +15,7 @@
 					<a href="{{ url_for('screener.service', service_id=referral.from_app_user.service.id) }}">{{ referral.from_app_user.service.name }}</a><i class="fa fa-chevron-right"></i><a href="{{ url_for('screener.service', service_id=referral.to_service.id) }}">{{ referral.to_service.name }}</a>
 				</h2>
 				<p><a href="{{ url_for('screener.user', user_id=referral.from_app_user.id) }}">{{ referral.from_app_user.full_name }}</a></p>
-				<p><strong>{{ _("Referral Status") }}:</strong> {{ referral.status }}</p>
+				<p><strong>{{ _("Referral Status") }}:</strong> {% if referral.status in ('SENT', 'RECEIVED') %} sent, waiting for response {% else %} screening result received {% endif %}</p>
 				{% if referral.notes %}
 				<p class="history_notes"><strong>{{ _("Notes") }}</strong><br>
 				{{ referral.notes or "" }}</p>

--- a/app/views.py
+++ b/app/views.py
@@ -179,6 +179,13 @@ def patient_overview(id):
 
     patient.update_stats()
 
+    prescreen_results = calculate_pre_screen_results(
+        fpl=patient.fpl_percentage,
+        has_health_insurance=patient.insurance_status,
+        is_eligible_for_medicaid="",
+        service_ids=[current_user.service_id]
+    )
+
     form = ScreeningResultForm()
     sliding_scale_options = SlidingScale.query.filter(
         SlidingScale.service_id == current_user.service_id
@@ -213,12 +220,7 @@ def patient_overview(id):
         'patient_overview.html',
         patient=patient,
         form=form,
-        services=calculate_pre_screen_results(
-            fpl=patient.fpl_percentage,
-            has_health_insurance=patient.insurance_status,
-            is_eligible_for_medicaid="",
-            service_ids=[s.id for s in services]
-        )
+        service=prescreen_results[0]
     )
 
 


### PR DESCRIPTION
- Updates the patient overview page so that the eligibility criteria appear even when the patient hasn't answered the relevant questions. For example, it will list "Insurance: no answer" if the patient doesn't have any insurance info listed, rather than simply hiding the insurance row.
- The patient overview page now also lists the estimated sliding scale section.
- Renames the patient lists on the home page to be less confusing ("referrals waiting for response" rather than "open referrals", etc).
- Adjusts referral history to list statuses as "sent, waiting for response" or "screening result received" rather than open/received/completed.
